### PR TITLE
Adds link to github source for each function card

### DIFF
--- a/lib/doc/jsdoc-template/docs.html.handlebars
+++ b/lib/doc/jsdoc-template/docs.html.handlebars
@@ -54,7 +54,10 @@
         <section class="card" id="{{name}}">
             <h2>
                 <a tabindex="2" class="name" href="#{{name}}">{{name}}</a>
-                <span class="label label-category pull-right">{{category}}</span>
+                <span class="pull-right">
+                        <span class="label label-category">{{category}}</span>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v{{../version}}/src/{{name}}.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                </span>
             </h2>
 
             {{#if deprecated}}


### PR DESCRIPTION
This change adds a `View source on GitHub` link for each function.

If the change is welcome, do you want the updated generated docs html included as part of this PR as well?

Screenshot:
![screenshot](https://cloud.githubusercontent.com/assets/8951601/8122322/877b5410-10fb-11e5-90b4-47132a1b4d5f.png)