### PR TITLE
repl: treat {x: 1, y: 2} as object literal rather than block statement

### DIFF
--- a/repl/assets/js/repl.js
+++ b/repl/assets/js/repl.js
@@ -99,7 +99,7 @@
         var url = location.href;
         var project = new traceur.semantics.symbols.Project(url);
         var name = 'repl';
-        var contents = input.getValue();
+        var contents = input.getValue().replace(/^\s*[{][\s\S]*[}]\s*$/, '($&)');
         if (history.replaceState)
             history.replaceState(null, document.title,
                 '#' + encodeURIComponent(contents));


### PR DESCRIPTION
It's surprising that [`{x: 1, y: 2}`][1] is a syntax error. Node's REPL does something [similar][2].


[1]: http://ramdajs.com/repl/?v=0.15.1#%7Bx%3A%201%2C%20y%3A%202%7D
[2]: https://github.com/joyent/node/blob/v0.12.6/lib/repl.js#L265-L276
