### PR TITLE
First proposal for #24

### DIFF
--- a/lib/doc/jsdoc-template/docs.html.handlebars
+++ b/lib/doc/jsdoc-template/docs.html.handlebars
@@ -7,8 +7,10 @@
     <link rel="stylesheet" type="text/css" href="../style.css">
 </head>
 <body>
+    <input type="checkbox" id="open-nav">
     <header class="navbar navbar-fixed-top navbar-inverse container-fluid">
         <div class="navbar-header">
+            <label class="open-nav" for="open-nav"></label>
             <a class="navbar-brand" href="/">
                 <strong>Ramda</strong>
                 <span class="version">v{{version}}</span>

--- a/lib/doc/jsdoc-template/index.html.handlebars
+++ b/lib/doc/jsdoc-template/index.html.handlebars
@@ -7,8 +7,10 @@
     <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
+    <input type="checkbox" id="open-nav">
     <header class="navbar navbar-fixed-top navbar-inverse container-fluid">
         <div class="navbar-header">
+            <label class="open-nav" for="open-nav"></label>
             <a class="navbar-brand" href="#">
                 <strong>Ramda</strong>
                 <span class="version">v{{version}}</span>

--- a/lib/doc/less/header.less
+++ b/lib/doc/less/header.less
@@ -1,0 +1,49 @@
+@media screen and (max-width: 767px) { // 768px - 1
+
+    header {
+
+        .open-nav {
+            float: left;
+            position: relative;
+            width: @navbar-height;
+            height: @navbar-height;
+            margin: 0 0 0 -15px;
+            padding: 15px;
+            font-size: 24px;
+            line-height: 20px;
+            cursor: pointer;
+            color: #e1d0e6;
+            font-weight: normal;
+
+            background: none left top no-repeat;
+            background-image: url('data:image/svg+xml;charset=utf8,<svg xmlns="http://www.w3.org/2000/svg" width="50" height="100"><rect fill="#849" x="0" y="0" width="50" height="100"/><rect fill="#e1d0e6" x="14" y="15" width="22" height="4"/><rect fill="#e1d0e6" x="14" y="23" width="22" height="4"/><rect fill="#e1d0e6" x="14" y="31" width="22" height="4"/><rect fill="#fff" x="14" y="65" width="22" height="4"/><rect fill="#fff" x="14" y="73" width="22" height="4"/><rect fill="#fff" x="14" y="81" width="22" height="4"/></svg>');
+
+            &:hover {
+                color: white;
+                background-position: left bottom;
+            }
+        }
+        #open-nav:checked ~ & .open-nav {
+            background-position: left bottom;
+        }
+
+        .navbar-left {
+            position: fixed;
+            top: @navbar-height;
+            left: 0;
+            width: @sidebar-width;
+
+            border-width: 0 1px 1px 0;
+            border-style: solid;
+            border-color: #693476;
+            background-color: #849;
+            box-shadow: 5px 5px 11px -3px rgba(0, 0, 0, 0.2);
+
+            .navbar-nav,
+            .navbar-nav > li {
+                float: none;
+            }
+        }
+    }
+
+}

--- a/lib/doc/less/layout.less
+++ b/lib/doc/less/layout.less
@@ -19,27 +19,32 @@ header {
 .forkme {
     margin-top: 10px;
 }
-html.docs-page {
-    aside {
-        position: fixed;
-        left: 0;
-        top: @navbar-height;
-        bottom: 0;
-        width: @sidebar-width;
-    }
 
-    main {
-        .main-content();
-        position: fixed;
-        left: @sidebar-width;
-    }
-
-    body {
-        background: #eee;
+#open-nav {
+    display: none;
+}
+@media screen and (min-width: 768px) {
+    .open-nav {
+        display: none;
     }
 }
 
+/**
+ * Home
+ */
 html.home-page {
+    header .navbar-left {
+        transform: translateX(-@sidebar-width);
+        transition: transform 100ms ease-in;
+    }
+    #open-nav:checked ~ header .navbar-left {
+        transform: translateX(0);
+    }
+    @media screen and (min-width: 768px) {
+        header .navbar-left {
+            transform: translateX(0);
+        }
+    }
     body {
         .main-content();
         position: relative;
@@ -48,11 +53,68 @@ html.home-page {
         margin: @padding;
         margin-top: 0;
     }
-
     main {
         background: #fff;
         border: 1px solid white;
         box-shadow: 0 0 0 1px #ccc;
         border-radius: @border-radius-base;
+    }
+}
+
+/**
+ * Documentation
+ */
+html.docs-page {
+    header .navbar-left {
+        transform: translateX(-@sidebar-width);
+    }
+    header .navbar-left,
+    aside, main {
+        transition: transform 100ms ease-in;
+    }
+    aside {
+        position: fixed;
+        left: 0;
+        top: @navbar-height * 5; // (1x navbar-height + 4x menu item)
+        bottom: 0;
+        width: @sidebar-width;
+        transform: translateX(-@sidebar-width);
+    }
+    main {
+        .main-content();
+        position: fixed;
+        left: 0;
+        min-width: 320px;
+    }
+    body {
+        background: #eee;
+    }
+
+    #open-nav:checked ~ header .navbar-left,
+    #open-nav:checked ~ aside {
+        transform: translateX(0);
+    }
+    #open-nav:checked ~ main {
+        transform: translateX(@sidebar-width);
+    }
+
+    @media screen and (min-width: 768px) {
+        aside {
+            top: @navbar-height;
+        }
+        aside,
+        #open-nav:checked ~ aside {
+            position: fixed;
+            transform: translateX(0);
+        }
+        header .navbar-left,
+        #open-nav:checked ~ header .navbar-left {
+            transform: translateX(0);
+        }
+        main,
+        #open-nav:checked ~ main {
+            transform: translateX(0);
+            left: @sidebar-width;
+        }
     }
 }

--- a/lib/doc/less/ramda.less
+++ b/lib/doc/less/ramda.less
@@ -1,6 +1,7 @@
 @import "node_modules/bootstrap/less/bootstrap";
 @import "variables";
 @import "layout";
+@import "header";
 @import "sidebar";
 @import "card";
 @import "hljs";

--- a/lib/doc/main.js
+++ b/lib/doc/main.js
@@ -68,10 +68,22 @@ function isTopLink(elem) {
   return elem.getAttribute('href') === '#';
 }
 
+function isAnchorLink(elem) {
+  return elem.tagName === 'A' && elem.getAttribute('href').charAt(0) === '#';
+}
+
+function closeNav() {
+  document.getElementById('open-nav').checked = false;
+}
+
 function dispatchEvent(event) {
   var target = event.target;
   var parent = target.parentNode;
   var category = target.getAttribute('data-category');
+
+  if (isAnchorLink(target)) {
+    closeNav();
+  }
   if (category) {
     filterTocType(category);
   }


### PR DESCRIPTION
This PR contains my proposal for issue https://github.com/ramda/ramda.github.io/issues/24

This was my proof of concept, with the inner workings for the css-only hamburger behaviour:
http://codepen.io/branneman/pen/BNvNQB/left/?editors=110
This was of course only a quick fix for the sidebar, my final solution has an optimised header & menu as well.

And I made a short demo video of how it works and feels on a small screen:
https://www.youtube.com/watch?v=A60DCGq2yCo

@buzzdecafe: Unfortunately I ended up with a hamburger icon, because of the small amount of space available. I would've preferred something different as well, but I didn't get it to look nice. The good news is that it's fairly easy to change in `header.less`, if you can think up something better in the future.

As an aside, I ran into some problems while trying to build the docs. The grunt task works, but the `npm run docs` fails when there's already a 0.17 directory which is not empty. As a temporary solution I've ran the build with `rm -rf 0.17 && npm run docs`. This works, but it's probably not how you guys are doing it. I am doing it the right way? It is wise to document this somewhere?