### PR TITLE
include @since, @typedefn, and additional @sig annotations

### DIFF
--- a/jsdoc/publish.js
+++ b/jsdoc/publish.js
@@ -13,13 +13,26 @@ if (!Object.prototype.hasOwnProperty.call(process.env, 'VERSION')) {
 var VERSION = process.env.VERSION;
 
 
-var valueForTitle = function(title, xs) {
+var headOr = function(x, xs) {
+  return xs.length === 0 ? x : xs[0];
+};
+
+var chain = function(f, xs) {
+  var result = [];
+  for (var idx = 0; idx < xs.length; idx += 1) {
+    result = result.concat(f(xs[idx]));
+  }
+  return result;
+};
+
+var valuesForTitle = function(title, xs) {
+  var result = [];
   for (var idx = 0; idx < xs.length; idx += 1) {
     if (xs[idx].title === title) {
-      return xs[idx].value;
+      result.push(xs[idx].value);
     }
   }
-  return '';
+  return result;
 };
 
 var prettifySig = function(s) {
@@ -45,8 +58,8 @@ var simplifySee = function(xs) {
 
 var simplifyData = function(d) {
   return {
-    aka: valueForTitle('aka', d.tags) === '' ? [] : valueForTitle('aka', d.tags).split(/,\s*/),
-    category: valueForTitle('category', d.tags),
+    aka: chain(function(s) { return s.split(/,\s*/); }, valuesForTitle('aka', d.tags)),
+    category: headOr('', valuesForTitle('category', d.tags)),
     deprecated: d.deprecated == null ? '' : d.deprecated,
     description: d.description == null ? '' : marked(d.description),
     example: d.examples == null ? [] : prettifyCode(d.examples),
@@ -75,7 +88,9 @@ var simplifyData = function(d) {
           '',
     },
     see: d.see == null ? [] : simplifySee(d.see),
-    sig: prettifySig(valueForTitle('sig', d.tags)),
+    sigs: valuesForTitle('sig', d.tags).map(prettifySig),
+    since: d.since == null ? '' : d.since,
+    typedefns: valuesForTitle('typedefn', d.tags).map(prettifySig),
   };
 };
 

--- a/jsdoc/templates/docs/index.html.handlebars
+++ b/jsdoc/templates/docs/index.html.handlebars
@@ -68,33 +68,41 @@
             </div>
             {{/if}}
 
-            {{#if sig}}
-            <div>
-                <button class="sig btn btn-link" data-collapser="#__details-{{name}}">
-                    <span class="caret rotated"></span>
-                    {{sig}}
-                </button>
+            {{#each sigs}}
+            <div><code>{{this}}</code></div>
+            {{/each}}
+
+            {{#each typedefns}}
+            <div><code>{{this}}</code></div>
+            {{/each}}
+
+            {{#if returns.type}}
+            <div class="params" data-expanded="false">
+                <a href="#expand" class="toggle-params">Parameters</a>
+                <div class="details panel panel-default">
+                    <ul class="list-group">
+                        {{#each params}}
+                        <li class="list-group-item">
+                            <span class="type">{{type}}</span>
+                            <span class="name">{{name}}</span>
+                            <span class="description">{{{description}}}</span>
+                        </li>
+                        {{/each}}
+                    </ul>
+                    <div class="panel-body">
+                        {{#with returns}}
+                        <span class="returns">Returns</span>
+                        <span class="type">{{type}}</span>
+                        <span class="description">{{{description}}}</span>
+                        {{/with}}
+                    </div>
+                </div>
             </div>
             {{/if}}
 
-            <div class="details collapse panel panel-default" id="__details-{{name}}">
-                <ul class="list-group">
-                    {{#each params}}
-                    <li class="list-group-item">
-                        <span class="type">{{type}}</span>
-                        <span class="name">{{name}}</span>
-                        <span class="description">{{{description}}}</span>
-                    </li>
-                    {{/each}}
-                </ul>
-                <div class="panel-body">
-                    {{#with returns}}
-                    <span class="returns">Returns</span>
-                    <span class="type">{{type}}</span>
-                    <span class="description">{{{description}}}</span>
-                    {{/with}}
-                </div>
-            </div>
+            {{#if since}}
+            <p><small>Added in {{since}}</small></p>
+            {{/if}}
 
             <div class="description">{{{description}}}</div>
 

--- a/less/ramda.less
+++ b/less/ramda.less
@@ -14,3 +14,24 @@
     background: mix(@brand-primary, #fff, 25%);
     color: @brand-primary;
 }
+
+.params .toggle-params {
+    font-size: 60%;
+    text-transform: uppercase;
+}
+
+.params[data-expanded="false"] > .toggle-params::before {
+    content: "Expand ";
+}
+
+.params[data-expanded="true"] > .toggle-params::before {
+    content: "Collapse ";
+}
+
+.params[data-expanded="false"] > .details {
+    display: none;
+}
+
+.params[data-expanded="true"] > .details {
+    display: block;
+}

--- a/main.js
+++ b/main.js
@@ -1,113 +1,112 @@
 /* global document, window, R */
 
-var findFirst = R.find(R.prop('offsetParent'));
+(function() {
 
-function toArray(xs) {
-  return Array.prototype.slice.call(xs);
-}
+  var findFirst = R.find(R.prop('offsetParent'));
 
-function filterTocType(category) {
-  nameFilter.value = category;
+  function toArray(xs) {
+    return Array.prototype.slice.call(xs);
+  }
+
+  function filterTocType(category) {
+    nameFilter.value = category;
+    filterToc();
+  }
+
+  function filterToc() {
+    var f = filterElement.bind(null, nameFilter.value);
+    funcs.forEach(f);
+  }
+
+  function filterElement(nameFilter, elem) {
+    elem.style.display =
+      strIn(nameFilter, elem.getAttribute('data-name')) ||
+      R.toLower(nameFilter) === R.toLower(elem.getAttribute('data-category')) ?
+        '' :
+        'none';
+  }
+
+  function gotoFirst(e) {
+    if (R.isEmpty(e.detail)) {
+      return;
+    }
+
+    var func = findFirst(funcs);
+    if (func) {
+      var onHashChange = function() {
+        e.target.focus();
+        window.removeEventListener('hashchange', onHashChange);
+      };
+
+      // Hash change blurs input, put focus back to input
+      window.addEventListener('hashchange', onHashChange);
+      window.location.hash = func.getAttribute('data-name');
+    }
+  }
+
+  function strIn(a, b) {
+    a = a.toLowerCase();
+    b = b.toLowerCase();
+    return b.indexOf(a) >= 0;
+  }
+
+  function scrollToTop() {
+    var main = document.querySelector('main');
+    main.scrollTop = 0;
+  }
+
+  function isTopLink(elem) {
+    return elem.getAttribute('href') === '#';
+  }
+
+  function isAnchorLink(elem) {
+    return elem.tagName === 'A' && elem.getAttribute('href').charAt(0) === '#';
+  }
+
+  function closeNav() {
+    document.getElementById('open-nav').checked = false;
+  }
+
+  function dispatchEvent(event) {
+    var target = event.target;
+    var category = target.getAttribute('data-category');
+
+    if (isAnchorLink(target)) {
+      closeNav();
+    }
+    if (category) {
+      filterTocType(category);
+    }
+    if (isTopLink(target)) {
+      scrollToTop(target);
+    }
+  }
+
+  function keypress(e) {
+    if (e.which === 13) {
+      e.target.dispatchEvent(new window.CustomEvent('enter', {
+        detail: e.target.value
+      }));
+    }
+  }
+
+  var nameFilter = document.getElementById('name-filter');
+  var funcs = toArray(document.querySelectorAll('.toc .func'));
   filterToc();
-}
 
-function filterToc() {
-  var f = filterElement.bind(null, nameFilter.value);
-  funcs.forEach(f);
-}
+  document.body.addEventListener('click', dispatchEvent, false);
+  nameFilter.addEventListener('input', filterToc, false);
+  nameFilter.addEventListener('keypress', keypress, false);
+  nameFilter.addEventListener('enter', gotoFirst);
 
-function filterElement(nameFilter, elem) {
-  var name = elem.getAttribute('data-name');
-  var category = elem.getAttribute('data-category');
-  var matches = strIn(nameFilter, name) || R.toLower(nameFilter) === R.toLower(category);
-  elem.style.display = matches ? '' : 'none';
-}
+  document.body.addEventListener('click', function(event) {
+    if (event.target.className.split(' ').indexOf('toggle-params') >= 0) {
+      var expanded = event.target.parentNode.getAttribute('data-expanded');
+      event.target.parentNode.setAttribute(
+        'data-expanded',
+        expanded === 'true' ? 'false' : 'true'
+      );
+    }
+  }, false);
 
-function gotoFirst(e) {
-  if (R.isEmpty(e.detail)) {
-    return;
-  }
-
-  var func = findFirst(funcs);
-  if (func) {
-    var onHashChange = function() {
-      e.target.focus();
-      window.removeEventListener('hashchange', onHashChange);
-    };
-
-    // Hash change blurs input, put focus back to input
-    window.addEventListener('hashchange', onHashChange);
-    window.location.hash = func.getAttribute('data-name');
-  }
-}
-
-function strIn(a, b) {
-  a = a.toLowerCase();
-  b = b.toLowerCase();
-  return b.indexOf(a) >= 0;
-}
-
-function scrollToTop() {
-  var main = document.querySelector('main');
-  main.scrollTop = 0;
-}
-
-function tryToggleCollapse(elem) {
-  var sel = elem && elem.getAttribute('data-collapser');
-  if (!sel) { return; }
-  elem
-    .classList
-    .toggle('open');
-  document
-    .querySelector(sel)
-    .classList
-    .toggle('in');
-}
-
-function isTopLink(elem) {
-  return elem.getAttribute('href') === '#';
-}
-
-function isAnchorLink(elem) {
-  return elem.tagName === 'A' && elem.getAttribute('href').charAt(0) === '#';
-}
-
-function closeNav() {
-  document.getElementById('open-nav').checked = false;
-}
-
-function dispatchEvent(event) {
-  var target = event.target;
-  var parent = target.parentNode;
-  var category = target.getAttribute('data-category');
-
-  if (isAnchorLink(target)) {
-    closeNav();
-  }
-  if (category) {
-    filterTocType(category);
-  }
-  if (isTopLink(target)) {
-    scrollToTop(target);
-  } else {
-    tryToggleCollapse(target);
-    tryToggleCollapse(parent);
-  }
-}
-
-function keypress(e) {
-  if (e.which == 13) {
-    e.target.dispatchEvent(new window.CustomEvent('enter', {
-      detail: e.target.value
-    }));
-  }
-}
-
-var nameFilter = document.getElementById('name-filter');
-var funcs = toArray(document.querySelectorAll('.toc .func'));
-filterToc();
-
-document.body.addEventListener('click', dispatchEvent, false);
-nameFilter.addEventListener('input', filterToc, false);
-nameFilter.addEventListener('keypress', keypress, false);
-nameFilter.addEventListener('enter', gotoFirst);
+}.call(this));


### PR DESCRIPTION
Dependent on #34, which I will merge before merging this pull request.

@CrossEye, please run `VERSION=0.18.0 make` to see whether you are happy with the following:

  - the styling of type signatures;
  - the handling of functions with multiple type signatures (see `R.take`, for example);
  - the styling of type definitions (see `R.view`, for example);
  - the links for toggling the visibility of parameter details; and
  - the rendering of `@since` annotations.

I'll admit that the design looks a bit like a dog's breakfast with these additions, but this shouldn't prevent us from making useful content available to users. Presenting this content in a sensible manner will require time and thought from a designer such as @ricburton.
