### PR TITLE
update "docs" directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ $(VERSION)/style.css: $(LESS_FILES)
 	mkdir -p '$(@D)'
 	$(LESS) less/ramda.less >'$@'
 
+docs/%: $(VERSION)/docs/%
+	mkdir -p '$(@D)'
+	cp '$<' '$@'
+
 .PHONY: index.html
 index.html: check-version
 	echo '<!DOCTYPE html><html><head><link rel="canonical" href="http://ramdajs.com/$(VERSION)/index.html" /><script>window.location = "$(VERSION)/index.html" + window.location.hash;</script></head><body></body></html>' >'$@'

--- a/docs/dist/ramda.js
+++ b/docs/dist/ramda.js
@@ -1,4 +1,4 @@
-//  Ramda v0.17.1
+//  Ramda v0.18.0
 //  https://github.com/ramda/ramda
 //  (c) 2013-2015 Scott Sauyet, Michael Hurley, and David Chambers
 //  Ramda may be freely distributed under the MIT license.
@@ -25,6 +25,7 @@
      *
      * @constant
      * @memberOf R
+     * @since v0.6.0
      * @category Function
      * @example
      *
@@ -86,6 +87,15 @@
         }
     };
 
+    var _arrayFromIterator = function _arrayFromIterator(iter) {
+        var list = [];
+        var next;
+        while (!(next = iter.next()).done) {
+            list.push(next.value);
+        }
+        return list;
+    };
+
     var _cloneRegExp = function _cloneRegExp(pattern) {
         return new RegExp(pattern.source, (pattern.global ? 'g' : '') + (pattern.ignoreCase ? 'i' : '') + (pattern.multiline ? 'm' : '') + (pattern.sticky ? 'y' : '') + (pattern.unicode ? 'u' : ''));
     };
@@ -139,7 +149,7 @@
     };
 
     /**
-     * Optimized internal two-arity curry function.
+     * Optimized internal one-arity curry function.
      *
      * @private
      * @category Function
@@ -330,6 +340,15 @@
         return x;
     };
 
+    var _isArguments = function () {
+        var toString = Object.prototype.toString;
+        return toString.call(arguments) === '[object Arguments]' ? function _isArguments(x) {
+            return toString.call(x) === '[object Arguments]';
+        } : function _isArguments(x) {
+            return _has('callee', x);
+        };
+    }();
+
     /**
      * Tests whether or not an object is an array.
      *
@@ -362,6 +381,14 @@
         return Object.prototype.toString.call(x) === '[object Number]';
     };
 
+    var _isObject = function _isObject(x) {
+        return Object.prototype.toString.call(x) === '[object Object]';
+    };
+
+    var _isRegExp = function _isRegExp(x) {
+        return Object.prototype.toString.call(x) === '[object RegExp]';
+    };
+
     var _isString = function _isString(x) {
         return Object.prototype.toString.call(x) === '[object String]';
     };
@@ -370,13 +397,19 @@
         return typeof obj['@@transducer/step'] === 'function';
     };
 
-    var _map = function _map(fn, list) {
-        var idx = 0, len = list.length, result = Array(len);
+    var _map = function _map(fn, functor) {
+        var idx = 0;
+        var len = functor.length;
+        var result = Array(len);
         while (idx < len) {
-            result[idx] = fn(list[idx]);
+            result[idx] = fn(functor[idx]);
             idx += 1;
         }
         return result;
+    };
+
+    var _of = function _of(x) {
+        return [x];
     };
 
     var _pipe = function _pipe(f, g) {
@@ -394,8 +427,11 @@
         };
     };
 
+    // \b matches word boundary; [\b] matches backspace
     var _quote = function _quote(s) {
-        return '"' + s.replace(/"/g, '\\"') + '"';
+        var escaped = s.replace(/\\/g, '\\\\').replace(/[\b]/g, '\\b')    // \b matches word boundary; [\b] matches backspace
+    .replace(/\f/g, '\\f').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t').replace(/\v/g, '\\v').replace(/\0/g, '\\0');
+        return '"' + escaped.replace(/"/g, '\\"') + '"';
     };
 
     var _reduced = function _reduced(x) {
@@ -674,6 +710,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Math
      * @sig Number -> Number -> Number
      * @param {Number} a
@@ -697,6 +734,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.14.0
      * @category List
      * @sig (a -> a) -> Number -> [a] -> [a]
      * @param {Function} fn The function to apply.
@@ -731,6 +769,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
      * @sig a -> (* -> a)
      * @param {*} val The value to wrap in a function
@@ -747,31 +786,26 @@
     });
 
     /**
-     * Returns a new list, composed of n-tuples of consecutive elements
-     * If `n` is greater than the length of the list, an empty list is returned.
+     * Returns `true` if both arguments are `true`; `false` otherwise.
      *
      * @func
      * @memberOf R
-     * @category List
-     * @sig Number -> [a] -> [[a]]
-     * @param {Number} n The size of the tuples to create
-     * @param {Array} list The list to split into `n`-tuples
-     * @return {Array} The new list.
+     * @since v0.1.0
+     * @category Logic
+     * @sig * -> * -> *
+     * @param {Boolean} a A boolean value
+     * @param {Boolean} b A boolean value
+     * @return {Boolean} `true` if both arguments are `true`, `false` otherwise
+     * @see R.both
      * @example
      *
-     *      R.aperture(2, [1, 2, 3, 4, 5]); //=> [[1, 2], [2, 3], [3, 4], [4, 5]]
-     *      R.aperture(3, [1, 2, 3, 4, 5]); //=> [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
-     *      R.aperture(7, [1, 2, 3, 4, 5]); //=> []
+     *      R.and(true, true); //=> true
+     *      R.and(true, false); //=> false
+     *      R.and(false, true); //=> false
+     *      R.and(false, false); //=> false
      */
-    var aperture = _curry2(function aperture(n, list) {
-        var idx = 0;
-        var limit = list.length - (n - 1);
-        var acc = new Array(limit >= 0 ? limit : 0);
-        while (idx < limit) {
-            acc[idx] = _slice(list, idx, idx + n);
-            idx += 1;
-        }
-        return acc;
+    var and = _curry2(function and(a, b) {
+        return a && b;
     });
 
     /**
@@ -780,6 +814,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig a -> [a] -> [a]
      * @param {*} el The element to add to the end of the new list.
@@ -804,6 +839,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.7.0
      * @category Function
      * @sig (*... -> a) -> [*] -> a
      * @param {Function} fn
@@ -827,6 +863,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.8.0
      * @category Object
      * @sig String -> a -> {k: v} -> {k: v}
      * @param {String} prop the property name to set
@@ -856,6 +893,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.8.0
      * @category Object
      * @sig [String] -> a -> {k: v} -> {k: v}
      * @param {Array} path the path to set
@@ -885,6 +923,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.6.0
      * @category Function
      * @category Object
      * @see R.partial
@@ -900,47 +939,18 @@
     });
 
     /**
-     * A function wrapping calls to the two functions in an `&&` operation, returning the result of the first
-     * function if it is false-y and the result of the second function otherwise.  Note that this is
-     * short-circuited, meaning that the second function will not be invoked if the first returns a false-y
-     * value.
-     *
-     * @func
-     * @memberOf R
-     * @category Logic
-     * @sig (*... -> Boolean) -> (*... -> Boolean) -> (*... -> Boolean)
-     * @param {Function} f a predicate
-     * @param {Function} g another predicate
-     * @return {Function} a function that applies its arguments to `f` and `g` and `&&`s their outputs together.
-     * @see R.and
-     * @example
-     *
-     *      var gt10 = function(x) { return x > 10; };
-     *      var even = function(x) { return x % 2 === 0 };
-     *      var f = R.both(gt10, even);
-     *      f(100); //=> true
-     *      f(101); //=> false
-     */
-    var both = _curry2(function both(f, g) {
-        return function _both() {
-            return f.apply(this, arguments) && g.apply(this, arguments);
-        };
-    });
-
-    /**
      * Makes a comparator function out of a function that reports whether the first element is less than the second.
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
      * @sig (a, b -> Boolean) -> (a, b -> Number)
      * @param {Function} pred A predicate function of arity two.
      * @return {Function} A Function :: a -> b -> Int that returns `-1` if a < b, `1` if b < a, otherwise `0`.
      * @example
      *
-     *      var cmp = R.comparator(function(a, b) {
-     *        return a.age < b.age;
-     *      });
+     *      var cmp = R.comparator((a, b) => a.age < b.age);
      *      var people = [
      *        // ...
      *      ];
@@ -953,31 +963,6 @@
     });
 
     /**
-     * Takes a function `f` and returns a function `g` such that:
-     *
-     *   - applying `g` to zero or more arguments will give __true__ if applying
-     *     the same arguments to `f` gives a logical __false__ value; and
-     *
-     *   - applying `g` to zero or more arguments will give __false__ if applying
-     *     the same arguments to `f` gives a logical __true__ value.
-     *
-     * @func
-     * @memberOf R
-     * @category Logic
-     * @sig (*... -> *) -> (*... -> Boolean)
-     * @param {Function} f
-     * @return {Function}
-     * @see R.not
-     * @example
-     *
-     *      var isEven = function(n) { return n % 2 === 0; };
-     *      var isOdd = R.complement(isEven);
-     *      isOdd(21); //=> true
-     *      isOdd(42); //=> false
-     */
-    var complement = _curry1(_complement);
-
-    /**
      * Returns a function, `fn`, which encapsulates if/else-if/else logic.
      * `R.cond` takes a list of [predicate, transform] pairs. All of the
      * arguments to `fn` are applied to each of the predicates in turn
@@ -987,6 +972,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.6.0
      * @category Logic
      * @sig [[(*... -> Boolean),(*... -> *)]] -> (*... -> *)
      * @param {Array} pairs
@@ -996,7 +982,7 @@
      *      var fn = R.cond([
      *        [R.equals(0),   R.always('water freezes at 0°C')],
      *        [R.equals(100), R.always('water boils at 100°C')],
-     *        [R.T,           function(temp) { return 'nothing special happens at ' + temp + '°C'; }]
+     *        [R.T,           temp => 'nothing special happens at ' + temp + '°C']
      *      ]);
      *      fn(0); //=> 'water freezes at 0°C'
      *      fn(50); //=> 'nothing special happens at 50°C'
@@ -1020,17 +1006,21 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.5
      * @category List
      * @sig (a, a -> Boolean) -> a -> [a] -> Boolean
      * @param {Function} pred A predicate used to test whether two items are equal.
      * @param {*} x The item to find
      * @param {Array} list The list to iterate over
      * @return {Boolean} `true` if `x` is in `list`, else `false`.
+     * @deprecated since v0.18.0
      * @example
      *
-     *      var xs = [{x: 12}, {x: 11}, {x: 10}];
-     *      R.containsWith(function(a, b) { return a.x === b.x; }, {x: 10}, xs); //=> true
-     *      R.containsWith(function(a, b) { return a.x === b.x; }, {x: 1}, xs); //=> false
+     *      var absEq = (a, b) => Math.abs(a) === Math.abs(b);
+     *      R.containsWith(absEq, 5, [1, 2, 3]); //=> false
+     *      R.containsWith(absEq, 5, [4, 5, 6]); //=> true
+     *      R.containsWith(absEq, 5, [-1, -2, -3]); //=> false
+     *      R.containsWith(absEq, 5, [-4, -5, -6]); //=> true
      */
     var containsWith = _curry3(_containsWith);
 
@@ -1043,6 +1033,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig (a -> String) -> [a] -> {*}
      * @param {Function} fn The function used to map values to keys.
@@ -1065,30 +1056,6 @@
             idx += 1;
         }
         return counts;
-    });
-
-    /**
-     * Creates an object containing a single key:value pair.
-     *
-     * @func
-     * @memberOf R
-     * @category Object
-     * @sig String -> a -> {String:a}
-     * @param {String} key
-     * @param {*} val
-     * @return {Object}
-     * @example
-     *
-     *      var matchPhrases = R.compose(
-     *        R.createMapEntry('must'),
-     *        R.map(R.createMapEntry('match_phrase'))
-     *      );
-     *      matchPhrases(['foo', 'bar', 'baz']); //=> {must: [{match_phrase: 'foo'}, {match_phrase: 'bar'}, {match_phrase: 'baz'}]}
-     */
-    var createMapEntry = _curry2(function createMapEntry(key, val) {
-        var obj = {};
-        obj[key] = val;
-        return obj;
     });
 
     /**
@@ -1117,6 +1084,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.5.0
      * @category Function
      * @sig Number -> (* -> a) -> (* -> a)
      * @param {Number} length The arity for the returned function.
@@ -1125,11 +1093,9 @@
      * @see R.curry
      * @example
      *
-     *      var addFourNumbers = function() {
-     *        return R.sum([].slice.call(arguments, 0, 4));
-     *      };
+     *      var sumArgs = (...args) => R.sum(args);
      *
-     *      var curriedAddFourNumbers = R.curryN(4, addFourNumbers);
+     *      var curriedAddFourNumbers = R.curryN(4, sumArgs);
      *      var f = curriedAddFourNumbers(1, 2);
      *      var g = f(3);
      *      g(4); //=> 10
@@ -1146,6 +1112,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Math
      * @sig Number -> Number
      * @param {Number} n
@@ -1158,11 +1125,12 @@
     var dec = add(-1);
 
     /**
-     * Returns the second argument if it is not null or undefined. If it is null
-     * or undefined, the first (default) argument is returned.
+     * Returns the second argument if it is not `null`, `undefined` or `NaN`
+     * otherwise the first argument is returned.
      *
      * @func
      * @memberOf R
+     * @since v0.10.0
      * @category Logic
      * @sig a -> b -> a | b
      * @param {a} val The default value.
@@ -1170,14 +1138,15 @@
      * @return {*} The the second value or the default value
      * @example
      *
-     *      var defaultTo42 = defaultTo(42);
+     *      var defaultTo42 = R.defaultTo(42);
      *
      *      defaultTo42(null);  //=> 42
      *      defaultTo42(undefined);  //=> 42
      *      defaultTo42('Ramda');  //=> 'Ramda'
+     *      defaultTo42(parseInt('string')); //=> 42
      */
     var defaultTo = _curry2(function defaultTo(d, v) {
-        return v == null ? d : v;
+        return v == null || v !== v ? d : v;
     });
 
     /**
@@ -1187,6 +1156,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig (a,a -> Boolean) -> [a] -> [a] -> [a]
      * @param {Function} pred A predicate used to test whether two items are equal.
@@ -1196,7 +1166,7 @@
      * @return {Array} The elements in `list1` that are not in `list2`.
      * @example
      *
-     *      function cmp(x, y) { return x.a === y.a; }
+     *      function cmp(x, y) => x.a === y.a;
      *      var l1 = [{a: 1}, {a: 2}, {a: 3}];
      *      var l2 = [{a: 3}, {a: 4}];
      *      R.differenceWith(cmp, l1, l2); //=> [{a: 1}, {a: 2}]
@@ -1220,6 +1190,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.10.0
      * @category Object
      * @sig String -> {k: v} -> {k: v}
      * @param {String} prop the name of the property to dissociate
@@ -1248,6 +1219,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.11.0
      * @category Object
      * @sig [String] -> {k: v} -> {k: v}
      * @param {Array} path the path to set
@@ -1276,6 +1248,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Math
      * @sig Number -> Number -> Number
      * @param {Number} a The first value.
@@ -1304,6 +1277,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.16.0
      * @category List
      * @sig (a -> Boolean) -> [a] -> [a]
      * @param {Function} fn The function called per iteration.
@@ -1312,11 +1286,9 @@
      * @see R.takeLastWhile
      * @example
      *
-     *      var lteThree = function(x) {
-     *        return x <= 3;
-     *      };
+     *      var lteThree = x => x <= 3;
      *
-     *      R.dropLastWhile(lteThree, [1, 2, 3, 4, 3, 2, 1]); //=> [1, 2]
+     *      R.dropLastWhile(lteThree, [1, 2, 3, 4, 3, 2, 1]); //=> [1, 2, 3, 4]
      */
     var dropLastWhile = _curry2(function dropLastWhile(pred, list) {
         var idx = list.length - 1;
@@ -1327,40 +1299,16 @@
     });
 
     /**
-     * A function wrapping calls to the two functions in an `||` operation, returning the result of the first
-     * function if it is truth-y and the result of the second function otherwise.  Note that this is
-     * short-circuited, meaning that the second function will not be invoked if the first returns a truth-y
-     * value.
-     *
-     * @func
-     * @memberOf R
-     * @category Logic
-     * @sig (*... -> Boolean) -> (*... -> Boolean) -> (*... -> Boolean)
-     * @param {Function} f a predicate
-     * @param {Function} g another predicate
-     * @return {Function} a function that applies its arguments to `f` and `g` and `||`s their outputs together.
-     * @see R.or
-     * @example
-     *
-     *      var gt10 = function(x) { return x > 10; };
-     *      var even = function(x) { return x % 2 === 0 };
-     *      var f = R.either(gt10, even);
-     *      f(101); //=> true
-     *      f(8); //=> true
-     */
-    var either = _curry2(function either(f, g) {
-        return function _either() {
-            return f.apply(this, arguments) || g.apply(this, arguments);
-        };
-    });
-
-    /**
      * Returns the empty value of its argument's type. Ramda defines the empty
-     * value of Array (`[]`), Object (`{}`), and String (`''`). Other types are
-     * supported if they define `<Type>.empty` and/or `<Type>.prototype.empty`.
+     * value of Array (`[]`), Object (`{}`), String (`''`), and Arguments.
+     * Other types are supported if they define `<Type>.empty` and/or
+     * `<Type>.prototype.empty`.
+     *
+     * Dispatches to the `empty` method of the first argument, if present.
      *
      * @func
      * @memberOf R
+     * @since v0.3.0
      * @category Function
      * @sig a -> a
      * @param {*} x
@@ -1372,32 +1320,24 @@
      *      R.empty('unicorns');    //=> ''
      *      R.empty({x: 1, y: 2});  //=> {}
      */
+    // else
     var empty = _curry1(function empty(x) {
-        if (x != null && typeof x.empty === 'function') {
-            return x.empty();
-        } else if (x != null && typeof x.constructor != null && typeof x.constructor.empty === 'function') {
-            return x.constructor.empty();
-        } else {
-            switch (Object.prototype.toString.call(x)) {
-            case '[object Array]':
-                return [];
-            case '[object Object]':
-                return {};
-            case '[object String]':
-                return '';
-            }
-        }
+        return x != null && typeof x.empty === 'function' ? x.empty() : x != null && x.constructor != null && typeof x.constructor.empty === 'function' ? x.constructor.empty() : _isArray(x) ? [] : _isString(x) ? '' : _isObject(x) ? {} : _isArguments(x) ? function () {
+            return arguments;
+        }() : // else
+        void 0;
     });
 
     /**
      * Creates a new object by recursively evolving a shallow copy of `object`, according to the
      * `transformation` functions. All non-primitive properties are copied by reference.
      *
-     * A `tranformation` function will not be invoked if its corresponding key does not exist in
+     * A `transformation` function will not be invoked if its corresponding key does not exist in
      * the evolved object.
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Object
      * @sig {k: (v -> v)} -> {k: v} -> {k: v}
      * @param {Object} transformations The object specifying transformation functions to apply
@@ -1429,11 +1369,12 @@
      *
      * @func
      * @memberOf R
+     * @since v0.3.0
      * @category List
      * @sig [[k,v]] -> {k: v}
      * @param {Array} pairs An array of two-element arrays that will be the keys and values of the output object.
      * @return {Object} The object made by pairing up `keys` and `values`.
-     * @see R.toPairs
+     * @see R.toPairs, R.pair
      * @example
      *
      *      R.fromPairs([['a', 1], ['b', 2],  ['c', 3]]); //=> {a: 1, b: 2, c: 3}
@@ -1455,6 +1396,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig Ord a => a -> a -> Boolean
      * @param {*} a
@@ -1479,6 +1421,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig Ord a => a -> a -> Boolean
      * @param {Number} a
@@ -1503,6 +1446,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.7.0
      * @category Object
      * @sig s -> {s: x} -> Boolean
      * @param {String} prop The name of the property to check for.
@@ -1529,6 +1473,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.7.0
      * @category Object
      * @sig s -> {s: x} -> Boolean
      * @param {String} prop The name of the property to check for.
@@ -1559,6 +1504,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.15.0
      * @category Relation
      * @sig a -> a -> Boolean
      * @param {*} a
@@ -1596,6 +1542,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
      * @sig a -> a
      * @param {*} x The value to return.
@@ -1615,7 +1562,9 @@
      *
      * @func
      * @memberOf R
+     * @since v0.8.0
      * @category Logic
+     * @see R.unless, R.when
      * @sig (*... -> Boolean) -> (*... -> *) -> (*... -> *) -> (*... -> *)
      * @param {Function} condition A predicate function
      * @param {Function} onTrue A function to invoke when the `condition` evaluates to a truthy value.
@@ -1624,11 +1573,13 @@
      *                    function depending upon the result of the `condition` predicate.
      * @example
      *
-     *      // Flatten all arrays in the list but leave other values alone.
-     *      var flattenArrays = R.map(R.ifElse(Array.isArray, R.flatten, R.identity));
-     *
-     *      flattenArrays([[0], [[10], [8]], 1234, {}]); //=> [[0], [10, 8], 1234, {}]
-     *      flattenArrays([[[10], 123], [8, [10]], "hello"]); //=> [[10, 123], [8, 10], "hello"]
+     *      var incCount = R.ifElse(
+     *        R.has('count'),
+     *        R.over(R.lensProp('count'), R.inc),
+     *        R.assoc('count', 1)
+     *      );
+     *      incCount({});           //=> { count: 1 }
+     *      incCount({ count: 1 }); //=> { count: 2 }
      */
     var ifElse = _curry3(function ifElse(condition, onTrue, onFalse) {
         return curryN(Math.max(condition.length, onTrue.length, onFalse.length), function _ifElse() {
@@ -1641,6 +1592,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Math
      * @sig Number -> Number
      * @param {Number} n
@@ -1659,6 +1611,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.2.2
      * @category List
      * @sig Number -> a -> [a] -> [a]
      * @param {Number} index The position to insert the element
@@ -1683,6 +1636,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category List
      * @sig Number -> [a] -> [a] -> [a]
      * @param {Number} index The position to insert the sub-list
@@ -1704,6 +1658,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.3.0
      * @category Type
      * @sig (* -> {*}) -> a -> Boolean
      * @param {Object} ctor A constructor
@@ -1729,6 +1684,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.5.0
      * @category Type
      * @category List
      * @sig * -> Boolean
@@ -1768,33 +1724,11 @@
     });
 
     /**
-     * Reports whether the list has zero elements.
-     *
-     * @func
-     * @memberOf R
-     * @category Logic
-     * @sig [a] -> Boolean
-     * @param {Array} list
-     * @return {Boolean}
-     * @example
-     *
-     *      R.isEmpty([1, 2, 3]);   //=> false
-     *      R.isEmpty([]);          //=> true
-     *      R.isEmpty('');          //=> true
-     *      R.isEmpty(null);        //=> false
-     *      R.isEmpty(R.keys({}));  //=> true
-     *      R.isEmpty({});          //=> false ({} does not have a length property)
-     *      R.isEmpty({length: 0}); //=> true
-     */
-    var isEmpty = _curry1(function isEmpty(list) {
-        return Object(list).length === 0;
-    });
-
-    /**
      * Checks if the input value is `null` or `undefined`.
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Type
      * @sig * -> Boolean
      * @param {*} x The value to test.
@@ -1818,6 +1752,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Object
      * @sig {k: v} -> [k]
      * @param {Object} obj The object to extract properties from
@@ -1883,6 +1818,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.2.0
      * @category Object
      * @sig {k: v} -> [k]
      * @param {Object} obj The object to extract properties from
@@ -1907,6 +1843,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.3.0
      * @category List
      * @sig [a] -> Number
      * @param {Array} list The array to inspect.
@@ -1926,6 +1863,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig Ord a => a -> a -> Boolean
      * @param {*} a
@@ -1950,6 +1888,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig Ord a => a -> a -> Boolean
      * @param {Number} a
@@ -1978,6 +1917,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.10.0
      * @category List
      * @sig (acc -> x -> (acc, y)) -> acc -> [x] -> (acc, [y])
      * @param {Function} fn The function to be called on every element of the input `list`.
@@ -1987,9 +1927,7 @@
      * @example
      *
      *      var digits = ['1', '2', '3', '4'];
-     *      var append = function(a, b) {
-     *        return [a + b, a + b];
-     *      }
+     *      var append = (a, b) => [a + b, a + b];
      *
      *      R.mapAccum(append, 0, digits); //=> ['01234', ['01', '012', '0123', '01234']]
      */
@@ -2019,6 +1957,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.10.0
      * @category List
      * @sig (acc -> x -> (acc, y)) -> acc -> [x] -> (acc, [y])
      * @param {Function} fn The function to be called on every element of the input `list`.
@@ -2028,9 +1967,7 @@
      * @example
      *
      *      var digits = ['1', '2', '3', '4'];
-     *      var append = function(a, b) {
-     *        return [a + b, a + b];
-     *      }
+     *      var append = (a, b) => [a + b, a + b];
      *
      *      R.mapAccumRight(append, 0, digits); //=> ['04321', ['04321', '0432', '043', '04']]
      */
@@ -2055,6 +1992,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @see R.test
      * @category String
      * @sig RegExp -> String -> [String | Undefined]
@@ -2079,6 +2017,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.3.0
      * @category Math
      * @sig Number -> Number -> Number
      * @param {Number} m The dividend.
@@ -2117,6 +2056,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig Ord a => a -> a -> a
      * @param {*} a
@@ -2138,6 +2078,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.8.0
      * @category Relation
      * @sig Ord b => (a -> b) -> a -> a -> a
      * @param {Function} f
@@ -2147,7 +2088,13 @@
      * @see R.max, R.minBy
      * @example
      *
-     *      R.maxBy(function(n) { return n * n; }, -3, 2); //=> -3
+     *      //  square :: Number -> Number
+     *      var square = n => n * n;
+     *
+     *      R.maxBy(square, -3, 2); //=> -3
+     *
+     *      R.reduce(R.maxBy(square), 0, [3, -5, 4, 1, -2]); //=> -5
+     *      R.reduce(R.maxBy(square), 0, []); //=> 0
      */
     var maxBy = _curry3(function maxBy(f, a, b) {
         return f(b) > f(a) ? b : a;
@@ -2159,6 +2106,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Object
      * @sig {k: v} -> {k: v} -> {k: v}
      * @param {Object} a
@@ -2194,6 +2142,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig Ord a => a -> a -> a
      * @param {*} a
@@ -2215,6 +2164,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.8.0
      * @category Relation
      * @sig Ord b => (a -> b) -> a -> a -> a
      * @param {Function} f
@@ -2224,7 +2174,13 @@
      * @see R.min, R.maxBy
      * @example
      *
-     *      R.minBy(function(n) { return n * n; }, -3, 2); //=> 2
+     *      //  square :: Number -> Number
+     *      var square = n => n * n;
+     *
+     *      R.minBy(square, -3, 2); //=> 2
+     *
+     *      R.reduce(R.minBy(square), Infinity, [3, -5, 4, 1, -2]); //=> 1
+     *      R.reduce(R.minBy(square), Infinity, []); //=> Infinity
      */
     var minBy = _curry3(function minBy(f, a, b) {
         return f(b) < f(a) ? b : a;
@@ -2232,11 +2188,12 @@
 
     /**
      * Divides the second parameter by the first and returns the remainder.
-     * Note that this functions preserves the JavaScript-style behavior for
-     * modulo. For mathematical modulo see `mathMod`
+     * Note that this function preserves the JavaScript-style behavior for
+     * modulo. For mathematical modulo see `mathMod`.
      *
      * @func
      * @memberOf R
+     * @since v0.1.1
      * @category Math
      * @sig Number -> Number -> Number
      * @param {Number} a The value to the divide.
@@ -2263,6 +2220,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Math
      * @sig Number -> Number -> Number
      * @param {Number} a The first value.
@@ -2287,6 +2245,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
      * @sig Number -> (* -> a) -> (* -> a)
      * @param {Number} n The desired arity of the new function.
@@ -2295,9 +2254,8 @@
      *         arity `n`.
      * @example
      *
-     *      var takesTwoArgs = function(a, b) {
-     *        return [a, b];
-     *      };
+     *      var takesTwoArgs = (a, b) => [a, b];
+     *
      *      takesTwoArgs.length; //=> 2
      *      takesTwoArgs(1, 2); //=> [1, 2]
      *
@@ -2362,6 +2320,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Math
      * @sig Number -> Number
      * @param {Number} n
@@ -2380,6 +2339,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Logic
      * @sig * -> Boolean
      * @param {*} a any value
@@ -2402,6 +2362,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig Number -> [a] -> a | Undefined
      * @sig Number -> String -> String
@@ -2428,6 +2389,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Function
      * @sig Number -> *... -> *
      * @param {Number} n
@@ -2444,43 +2406,29 @@
     });
 
     /**
-     * Returns the nth character of the given string.
+     * Creates an object containing a single key:value pair.
      *
      * @func
      * @memberOf R
-     * @category String
-     * @sig Number -> String -> String
-     * @param {Number} n
-     * @param {String} str
-     * @return {String}
-     * @deprecated since v0.16.0
+     * @since v0.18.0
+     * @category Object
+     * @sig String -> a -> {String:a}
+     * @param {String} key
+     * @param {*} val
+     * @return {Object}
+     * @see R.pair
      * @example
      *
-     *      R.nthChar(2, 'Ramda'); //=> 'm'
-     *      R.nthChar(-2, 'Ramda'); //=> 'd'
+     *      var matchPhrases = R.compose(
+     *        R.objOf('must'),
+     *        R.map(R.objOf('match_phrase'))
+     *      );
+     *      matchPhrases(['foo', 'bar', 'baz']); //=> {must: [{match_phrase: 'foo'}, {match_phrase: 'bar'}, {match_phrase: 'baz'}]}
      */
-    var nthChar = _curry2(function nthChar(n, str) {
-        return str.charAt(n < 0 ? str.length + n : n);
-    });
-
-    /**
-     * Returns the character code of the nth character of the given string.
-     *
-     * @func
-     * @memberOf R
-     * @category String
-     * @sig Number -> String -> Number
-     * @param {Number} n
-     * @param {String} str
-     * @return {Number}
-     * @deprecated since v0.16.0
-     * @example
-     *
-     *      R.nthCharCode(2, 'Ramda'); //=> 'm'.charCodeAt(0)
-     *      R.nthCharCode(-2, 'Ramda'); //=> 'd'.charCodeAt(0)
-     */
-    var nthCharCode = _curry2(function nthCharCode(n, str) {
-        return str.charCodeAt(n < 0 ? str.length + n : n);
+    var objOf = _curry2(function objOf(key, val) {
+        var obj = {};
+        obj[key] = val;
+        return obj;
     });
 
     /**
@@ -2491,6 +2439,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.3.0
      * @category Function
      * @sig a -> [a]
      * @param {*} x any value
@@ -2500,24 +2449,23 @@
      *      R.of(null); //=> [null]
      *      R.of([42]); //=> [[42]]
      */
-    var of = _curry1(function of(x) {
-        return [x];
-    });
+    var of = _curry1(_of);
 
     /**
      * Accepts a function `fn` and returns a function that guards invocation of `fn` such that
      * `fn` can only ever be called once, no matter how many times the returned function is
-     * invoked.
+     * invoked. The first value calculated is returned in subsequent invocations.
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
      * @sig (a... -> b) -> (a... -> b)
      * @param {Function} fn The function to wrap in a call-only-once wrapper.
      * @return {Function} The wrapped function.
      * @example
      *
-     *      var addOneOnce = R.once(function(x){ return x + 1; });
+     *      var addOneOnce = R.once(x => x + 1);
      *      addOneOnce(10); //=> 11
      *      addOneOnce(addOneOnce(50)); //=> 11
      */
@@ -2534,11 +2482,37 @@
     });
 
     /**
-     * Returns the result of "setting" the portion of the given data structure
-     * focused by the given lens to the given value.
+     * Returns `true` if one or both of its arguments are `true`. Returns `false`
+     * if both arguments are `false`.
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
+     * @category Logic
+     * @sig * -> * -> *
+     * @param {Boolean} a A boolean value
+     * @param {Boolean} b A boolean value
+     * @return {Boolean} `true` if one or both arguments are `true`, `false` otherwise
+     * @see R.either
+     * @example
+     *
+     *      R.or(true, true); //=> true
+     *      R.or(true, false); //=> true
+     *      R.or(false, true); //=> true
+     *      R.or(false, false); //=> false
+     */
+    var or = _curry2(function or(a, b) {
+        return a || b;
+    });
+
+    /**
+     * Returns the result of "setting" the portion of the given data structure
+     * focused by the given lens to the result of applying the given function to
+     * the focused value.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.16.0
      * @category Object
      * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
      * @sig Lens s a -> (a -> a) -> s -> s
@@ -2570,10 +2544,34 @@
     }();
 
     /**
+     * Takes two arguments, `fst` and `snd`, and returns `[fst, snd]`.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.18.0
+     * @category List
+     * @sig a -> b -> (a,b)
+     * @param {*} fst
+     * @param {*} snd
+     * @return {Array}
+     * @see R.createMapEntry, R.of
+     * @example
+     *
+     *      pair('foo', 'bar'); //=> ['foo', 'bar']
+     */
+    var pair = _curry2(function pair(fst, snd) {
+        return [
+            fst,
+            snd
+        ];
+    });
+
+    /**
      * Retrieve the value at a given path.
      *
      * @func
      * @memberOf R
+     * @since v0.2.0
      * @category Object
      * @sig [String] -> {k: v} -> v | Undefined
      * @param {Array} path The path to use.
@@ -2588,11 +2586,34 @@
             return;
         } else {
             var val = obj;
-            for (var idx = 0, len = paths.length; idx < len && val != null; idx += 1) {
+            var idx = 0;
+            while (val != null && idx < paths.length) {
                 val = val[paths[idx]];
+                idx += 1;
             }
             return val;
         }
+    });
+
+    /**
+     * If the given, non-null object has a value at the given path, returns
+     * the value at that path. Otherwise returns the provided default value.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.18.0
+     * @category Object
+     * @sig a -> [String] -> Object -> a
+     * @param {*} d The default value.
+     * @param {Array} p The path to use.
+     * @return {*} The data at `path` of the supplied object or the default value.
+     * @example
+     *
+     *      R.pathOr('N/A', ['a', 'b'], {a: {b: 2}}); //=> 2
+     *      R.pathOr('N/A', ['a', 'b'], {c: {b: 2}}); //=> "N/A"
+     */
+    var pathOr = _curry3(function pathOr(d, p, obj) {
+        return defaultTo(d, path(p, obj));
     });
 
     /**
@@ -2601,12 +2622,13 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Object
      * @sig [k] -> {k: v} -> {k: v}
      * @param {Array} names an array of String property names to copy onto a new object
      * @param {Object} obj The object to copy from
      * @return {Object} A new object with only properties from `names` on it.
-     * @see R.omit
+     * @see R.omit, R.props
      * @example
      *
      *      R.pick(['a', 'd'], {a: 1, b: 2, c: 3, d: 4}); //=> {a: 1, d: 4}
@@ -2629,6 +2651,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Object
      * @sig [k] -> {k: v} -> {k: v}
      * @param {Array} names an array of String property names to copy onto a new object
@@ -2658,6 +2681,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.8.0
      * @category Object
      * @sig (v, k -> Boolean) -> {k: v} -> {k: v}
      * @param {Function} pred A predicate to determine whether or not a key
@@ -2668,7 +2692,7 @@
      * @see R.pick
      * @example
      *
-     *      var isUpperCase = function(val, key) { return key.toUpperCase() === key; }
+     *      var isUpperCase = (val, key) => key.toUpperCase() === key;
      *      R.pickBy(isUpperCase, {a: 1, b: 2, A: 3, B: 4}); //=> {A: 3, B: 4}
      */
     var pickBy = _curry2(function pickBy(test, obj) {
@@ -2687,6 +2711,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig a -> [a] -> [a]
      * @param {*} el The item to add to the head of the output list.
@@ -2706,6 +2731,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Object
      * @sig s -> {s: a} -> a | Undefined
      * @param {String} p The property name
@@ -2727,6 +2753,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.6.0
      * @category Object
      * @sig a -> String -> Object -> a
      * @param {*} val The default value.
@@ -2755,6 +2782,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.16.0
      * @category Logic
      * @sig (a -> Boolean) -> String -> {String: a} -> Boolean
      * @param {Function} pred
@@ -2776,6 +2804,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Object
      * @sig [k] -> {k: v} -> [v]
      * @param {Array} ps The property names to fetch
@@ -2806,6 +2835,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig Number -> Number -> [Number]
      * @param {Number} from The first number in the list.
@@ -2844,6 +2874,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig (a,b -> a) -> a -> [b] -> a
      * @param {Function} fn The iterator function. Receives two values, the accumulator and the
@@ -2854,9 +2885,7 @@
      * @example
      *
      *      var pairs = [ ['a', 1], ['b', 2], ['c', 3] ];
-     *      var flattenPairs = function(acc, pair) {
-     *        return acc.concat(pair);
-     *      };
+     *      var flattenPairs = (acc, pair) => acc.concat(pair);
      *
      *      R.reduceRight(flattenPairs, [], pairs); //=> [ 'c', 3, 'b', 2, 'a', 1 ]
      */
@@ -2881,6 +2910,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.15.0
      * @category List
      * @see R.reduce, R.transduce
      * @sig a -> *
@@ -2889,7 +2919,7 @@
      * @example
      *
      *      R.reduce(
-     *        R.pipe(R.add, R.ifElse(R.lte(10), R.reduced, R.identity)),
+     *        R.pipe(R.add, R.when(R.gte(R.__, 10), R.reduced)),
      *        0,
      *        [1, 2, 3, 4, 5]) // 10
      */
@@ -2903,6 +2933,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.2.2
      * @category List
      * @sig Number -> Number -> [a] -> [a]
      * @param {Number} start The position to start removing elements
@@ -2922,6 +2953,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.7.0
      * @category String
      * @sig RegExp|String -> String -> String -> String
      * @param {RegExp|String} pattern A regular expression or a substring to match.
@@ -2941,24 +2973,31 @@
     });
 
     /**
-     * Returns a new list with the same elements as the original list, just
-     * in the reverse order.
+     * Returns a new list or string with the elements or characters in reverse
+     * order.
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig [a] -> [a]
-     * @param {Array} list The list to reverse.
-     * @return {Array} A copy of the list in reverse order.
+     * @sig String -> String
+     * @param {Array|String} list
+     * @return {Array|String}
      * @example
      *
      *      R.reverse([1, 2, 3]);  //=> [3, 2, 1]
      *      R.reverse([1, 2]);     //=> [2, 1]
      *      R.reverse([1]);        //=> [1]
      *      R.reverse([]);         //=> []
+     *
+     *      R.reverse('abc');      //=> 'cba'
+     *      R.reverse('ab');       //=> 'ba'
+     *      R.reverse('a');        //=> 'a'
+     *      R.reverse('');         //=> ''
      */
     var reverse = _curry1(function reverse(list) {
-        return _slice(list).reverse();
+        return _isString(list) ? list.split('').reverse().join('') : _slice(list).reverse();
     });
 
     /**
@@ -2966,6 +3005,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.10.0
      * @category List
      * @sig (a,b -> a) -> a -> [b] -> [a]
      * @param {Function} fn The iterator function. Receives two values, the accumulator and the
@@ -2994,6 +3034,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.16.0
      * @category Object
      * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
      * @sig Lens s a -> a -> s -> s
@@ -3020,6 +3061,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig (a,a -> Number) -> [a] -> [a]
      * @param {Function} comparator A sorting function :: a -> b -> Int
@@ -3039,6 +3081,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig Ord b => (a -> b) -> [a] -> [a]
      * @param {Function} fn
@@ -3046,7 +3089,7 @@
      * @return {Array} A new list sorted by the keys generated by `fn`.
      * @example
      *
-     *      var sortByFirstItem = R.sortBy(prop(0));
+     *      var sortByFirstItem = R.sortBy(R.prop(0));
      *      var sortByNameCaseInsensitive = R.sortBy(R.compose(R.toLower, R.prop('name')));
      *      var pairs = [[-1, 1], [-2, 2], [-3, 3]];
      *      sortByFirstItem(pairs); //=> [[-3, 3], [-2, 2], [-1, 1]]
@@ -3078,6 +3121,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Math
      * @sig Number -> Number -> Number
      * @param {Number} a The first value.
@@ -3107,6 +3151,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.16.0
      * @category List
      * @sig (a -> Boolean) -> [a] -> [a]
      * @param {Function} fn The function called per iteration.
@@ -3115,9 +3160,7 @@
      * @see R.dropLastWhile
      * @example
      *
-     *      var isNotOne = function(x) {
-     *        return !(x === 1);
-     *      };
+     *      var isNotOne = x => x !== 1;
      *
      *      R.takeLastWhile(isNotOne, [1, 2, 3, 4]); //=> [2, 3, 4]
      */
@@ -3134,6 +3177,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
      * @sig (a -> *) -> a -> a
      * @param {Function} fn The function to call with `x`. The return value of `fn` will be thrown away.
@@ -3141,33 +3185,13 @@
      * @return {*} `x`.
      * @example
      *
-     *      var sayX = function(x) { console.log('x is ' + x); };
+     *      var sayX = x => console.log('x is ' + x);
      *      R.tap(sayX, 100); //=> 100
      *      //-> 'x is 100'
      */
     var tap = _curry2(function tap(fn, x) {
         fn(x);
         return x;
-    });
-
-    /**
-     * Determines whether a given string matches a given regular expression.
-     *
-     * @func
-     * @memberOf R
-     * @see R.match
-     * @category String
-     * @sig RegExp -> String -> Boolean
-     * @param {RegExp} pattern
-     * @param {String} str
-     * @return {Boolean}
-     * @example
-     *
-     *      R.test(/^x/, 'xyz'); //=> true
-     *      R.test(/^y/, 'xyz'); //=> false
-     */
-    var test = _curry2(function test(pattern, str) {
-        return _cloneRegExp(pattern).test(str);
     });
 
     /**
@@ -3179,6 +3203,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.2.3
      * @category List
      * @sig (i -> a) -> i -> [a]
      * @param {Function} fn The function to invoke. Passed one argument, the current value of `n`.
@@ -3207,6 +3232,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.4.0
      * @category Object
      * @sig {String: *} -> [[String,*]]
      * @param {Object} obj The object to extract from
@@ -3237,6 +3263,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.4.0
      * @category Object
      * @sig {String: *} -> [[String,*]]
      * @param {Object} obj The object to extract from
@@ -3265,6 +3292,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.6.0
      * @category String
      * @sig String -> String
      * @param {String} str The string to trim.
@@ -3298,6 +3326,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.8.0
      * @category Type
      * @sig (* -> {*}) -> String
      * @param {*} val The value to test
@@ -3329,6 +3358,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.8.0
      * @category Function
      * @sig ([*...] -> a) -> (*... -> a)
      * @param {Function} fn
@@ -3350,6 +3380,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.2.0
      * @category Function
      * @sig (* -> b) -> (a -> b)
      * @param {Function} fn The function to wrap.
@@ -3377,6 +3408,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.14.0
      * @category Function
      * @sig Number -> (a -> b) -> (a -> c)
      * @param {Number} length The arity for the returned function.
@@ -3385,18 +3417,10 @@
      * @see R.curry
      * @example
      *
-     *      var addFour = function(a) {
-     *        return function(b) {
-     *          return function(c) {
-     *            return function(d) {
-     *              return a + b + c + d;
-     *            };
-     *          };
-     *        };
-     *      };
+     *      var addFour = a => b => c => d => a + b + c + d;
      *
      *      var uncurriedAddFour = R.uncurryN(4, addFour);
-     *      curriedAddFour(1, 2, 3, 4); //=> 10
+     *      uncurriedAddFour(1, 2, 3, 4); //=> 10
      */
     var uncurryN = _curry2(function uncurryN(depth, fn) {
         return curryN(depth, function () {
@@ -3423,6 +3447,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.10.0
      * @category List
      * @sig (a -> [b]) -> * -> [b]
      * @param {Function} fn The iterator function. receives one argument, `seed`, and returns
@@ -3433,7 +3458,7 @@
      * @return {Array} The final list.
      * @example
      *
-     *      var f = function(n) { return n > 50 ? false : [-n, n + 10] };
+     *      var f = n => n > 50 ? false : [-n, n + 10];
      *      R.unfold(f, 10); //=> [-10, -20, -30, -40, -50]
      */
     var unfold = _curry2(function unfold(fn, seed) {
@@ -3453,6 +3478,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.2.0
      * @category List
      * @sig (a, a -> Boolean) -> [a] -> [a]
      * @param {Function} pred A predicate used to test whether two items are equal.
@@ -3460,7 +3486,7 @@
      * @return {Array} The list of unique items.
      * @example
      *
-     *      var strEq = function(a, b) { return String(a) === String(b); };
+     *      var strEq = R.eqBy(String);
      *      R.uniqWith(strEq)([1, '1', 2, 1]); //=> [1, 2]
      *      R.uniqWith(strEq)([{}, {}]);       //=> [{}]
      *      R.uniqWith(strEq)([1, '1', 1]);    //=> [1]
@@ -3480,12 +3506,42 @@
     });
 
     /**
+     * Tests the final argument by passing it to the given predicate function.
+     * If the predicate is not satisfied, the function will return the
+     * result of calling the `whenFalseFn` function with the same argument. If the
+     * predicate is satisfied, the argument is returned as is.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.18.0
+     * @category Logic
+     * @see R.ifElse, R.when
+     * @sig (a -> Boolean) -> (a -> a) -> a -> a
+     * @param {Function} pred        A predicate function
+     * @param {Function} whenFalseFn A function to invoke when the `pred` evaluates
+     *                               to a falsy value.
+     * @param {*}        x           An object to test with the `pred` function and
+     *                               pass to `whenFalseFn` if necessary.
+     * @return {*} Either `x` or the result of applying `x` to `whenFalseFn`.
+     * @example
+     *
+     *      // coerceArray :: (a|[a]) -> [a]
+     *      var coerceArray = R.unless(R.isArrayLike, R.of);
+     *      coerceArray([1, 2, 3]); //=> [1, 2, 3]
+     *      coerceArray(1);         //=> [1]
+     */
+    var unless = _curry3(function unless(pred, whenFalseFn, x) {
+        return pred(x) ? x : whenFalseFn(x);
+    });
+
+    /**
      * Returns a new copy of the array with the element at the
      * provided index replaced with the given value.
      * @see R.adjust
      *
      * @func
      * @memberOf R
+     * @since v0.14.0
      * @category List
      * @sig Number -> a -> [a] -> [a]
      * @param {Number} idx The index to update.
@@ -3508,6 +3564,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Object
      * @sig {k: v} -> [v]
      * @param {Object} obj The object to extract values from
@@ -3536,6 +3593,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.2.0
      * @category Object
      * @sig {k: v} -> [v]
      * @param {Object} obj The object to extract values from
@@ -3561,6 +3619,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.16.0
      * @category Object
      * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
      * @sig Lens s a -> s -> a
@@ -3590,6 +3649,38 @@
     }();
 
     /**
+     * Tests the final argument by passing it to the given predicate function.
+     * If the predicate is satisfied, the function will return the result
+     * of calling the `whenTrueFn` function with the same argument. If the predicate
+     * is not satisfied, the argument is returned as is.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.18.0
+     * @category Logic
+     * @see R.ifElse, R.unless
+     * @sig (a -> Boolean) -> (a -> a) -> a -> a
+     * @param {Function} pred       A predicate function
+     * @param {Function} whenTrueFn A function to invoke when the `condition`
+     *                              evaluates to a truthy value.
+     * @param {*}        x          An object to test with the `pred` function and
+     *                              pass to `whenTrueFn` if necessary.
+     * @return {*} Either `x` or the result of applying `x` to `whenTrueFn`.
+     * @example
+     *
+     *      // truncate :: String -> String
+     *      var truncate = R.when(
+     *        R.propSatisfies(R.gt(R.__, 10), 'length'),
+     *        R.pipe(R.take(10), R.append('…'), R.join(''))
+     *      );
+     *      truncate('12345');         //=> '12345'
+     *      truncate('0123456789ABC'); //=> '0123456789…'
+     */
+    var when = _curry3(function when(pred, whenTrueFn, x) {
+        return pred(x) ? whenTrueFn(x) : x;
+    });
+
+    /**
      * Takes a spec object and a test object; returns true if the test satisfies
      * the spec. Each of the spec's own properties must be a predicate function.
      * Each predicate is applied to the value of the corresponding property of
@@ -3601,6 +3692,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.1
      * @category Object
      * @sig {String: (* -> Boolean)} -> {String: *} -> Boolean
      * @param {Object} spec
@@ -3637,6 +3729,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
      * @sig (a... -> b) -> ((a... -> b) -> a... -> c) -> (a... -> c)
      * @param {Function} fn The function to wrap.
@@ -3644,11 +3737,10 @@
      * @return {Function} The wrapped function.
      * @example
      *
-     *      var greet = function(name) {return 'Hello ' + name;};
+     *      var greet = name => 'Hello ' + name;
      *
-     *      var shoutedGreet = R.wrap(greet, function(gr, name) {
-     *        return gr(name).toUpperCase();
-     *      });
+     *      var shoutedGreet = R.wrap(greet, (gr, name) => gr(name).toUpperCase());
+     *
      *      shoutedGreet("Kathy"); //=> "HELLO KATHY"
      *
      *      var shortenedGreet = R.wrap(greet, function(gr, name) {
@@ -3668,6 +3760,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig [a] -> [b] -> [[a,b]]
      * @param {Array} as The first list.
@@ -3708,6 +3801,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig [a] -> [b] -> [[a,b]]
      * @param {Array} list1 The first array to consider.
@@ -3736,6 +3830,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.3.0
      * @category List
      * @sig [String] -> [*] -> {String: *}
      * @param {Array} keys The array that will be properties on the output object.
@@ -3761,6 +3856,7 @@
      *
      * @function
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig (a,b -> c) -> [a] -> [b] -> [c]
      * @param {Function} fn The function used to combine the two elements into one value.
@@ -3770,7 +3866,7 @@
      *         using `fn`.
      * @example
      *
-     *      var f = function(x, y) {
+     *      var f = (x, y) => {
      *        // ...
      *      };
      *      R.zipWith(f, [1, 2, 3], ['a', 'b', 'c']);
@@ -3790,9 +3886,11 @@
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Function
-     * @sig * -> false
-     * @return {Boolean} false
+     * @sig * -> Boolean
+     * @param {*}
+     * @return {Boolean}
      * @see R.always, R.T
      * @example
      *
@@ -3805,15 +3903,28 @@
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Function
-     * @sig * -> true
-     * @return {Boolean} `true`.
+     * @sig * -> Boolean
+     * @param {*}
+     * @return {Boolean}
      * @see R.always, R.F
      * @example
      *
      *      R.T(); //=> true
      */
     var T = always(true);
+
+    var _aperture = function _aperture(n, list) {
+        var idx = 0;
+        var limit = list.length - (n - 1);
+        var acc = new Array(limit >= 0 ? limit : 0);
+        while (idx < limit) {
+            acc[idx] = _slice(list, idx, idx + n);
+            idx += 1;
+        }
+        return acc;
+    };
 
     /**
      * Similar to hasMethod, this checks whether a function has a [methodname]
@@ -3877,12 +3988,11 @@
     };
 
     var _createPartialApplicator = function _createPartialApplicator(concat) {
-        return function (fn) {
-            var args = _slice(arguments, 1);
+        return _curry2(function (fn, args) {
             return _arity(Math.max(0, fn.length - args.length), function () {
                 return fn.apply(this, concat(args, arguments));
             });
-        };
+        });
     };
 
     /**
@@ -3920,75 +4030,88 @@
         };
     };
 
-    // The algorithm used to handle cyclic structures is
-    // inspired by underscore's isEqual
-    // RegExp equality algorithm: http://stackoverflow.com/a/10776635
+    // Values of other types are only equal if identical.
     var _equals = function _equals(a, b, stackA, stackB) {
-        var typeA = type(a);
-        if (typeA !== type(b)) {
-            return false;
-        }
-        if (typeA === 'Boolean' || typeA === 'Number' || typeA === 'String') {
-            return typeof a === 'object' ? typeof b === 'object' && identical(a.valueOf(), b.valueOf()) : identical(a, b);
-        }
         if (identical(a, b)) {
             return true;
         }
-        if (typeA === 'RegExp') {
-            // RegExp equality algorithm: http://stackoverflow.com/a/10776635
-            return a.source === b.source && a.global === b.global && a.ignoreCase === b.ignoreCase && a.multiline === b.multiline && a.sticky === b.sticky && a.unicode === b.unicode;
+        if (type(a) !== type(b)) {
+            return false;
         }
-        if (Object(a) === a) {
-            if (typeA === 'Date' && a.getTime() !== b.getTime()) {
+        if (a == null || b == null) {
+            return false;
+        }
+        if (typeof a.equals === 'function' || typeof b.equals === 'function') {
+            return typeof a.equals === 'function' && a.equals(b) && typeof b.equals === 'function' && b.equals(a);
+        }
+        switch (type(a)) {
+        case 'Arguments':
+        case 'Array':
+        case 'Object':
+            break;
+        case 'Boolean':
+        case 'Number':
+        case 'String':
+            if (!(typeof a === typeof b && identical(a.valueOf(), b.valueOf()))) {
                 return false;
             }
-            var keysA = keys(a);
-            if (keysA.length !== keys(b).length) {
+            break;
+        case 'Date':
+            if (!identical(a.valueOf(), b.valueOf())) {
                 return false;
             }
-            var idx = stackA.length - 1;
-            while (idx >= 0) {
-                if (stackA[idx] === a) {
-                    return stackB[idx] === b;
-                }
-                idx -= 1;
+            break;
+        case 'RegExp':
+            if (!(a.source === b.source && a.global === b.global && a.ignoreCase === b.ignoreCase && a.multiline === b.multiline && a.sticky === b.sticky && a.unicode === b.unicode)) {
+                return false;
             }
-            stackA[stackA.length] = a;
-            stackB[stackB.length] = b;
-            idx = keysA.length - 1;
-            while (idx >= 0) {
-                var key = keysA[idx];
-                if (!_has(key, b) || !_equals(b[key], a[key], stackA, stackB)) {
-                    return false;
-                }
-                idx -= 1;
+            break;
+        case 'Map':
+        case 'Set':
+            if (!_equals(_arrayFromIterator(a.entries()), _arrayFromIterator(b.entries()), stackA, stackB)) {
+                return false;
             }
-            stackA.pop();
-            stackB.pop();
-            return true;
+            break;
+        case 'Int8Array':
+        case 'Uint8Array':
+        case 'Uint8ClampedArray':
+        case 'Int16Array':
+        case 'Uint16Array':
+        case 'Int32Array':
+        case 'Uint32Array':
+        case 'Float32Array':
+        case 'Float64Array':
+            break;
+        case 'ArrayBuffer':
+            break;
+        default:
+            // Values of other types are only equal if identical.
+            return false;
         }
-        return false;
-    };
-
-    /**
-     * Private function that determines whether or not a provided object has a given method.
-     * Does not ignore methods stored on the object's prototype chain. Used for dynamically
-     * dispatching Ramda methods to non-Array objects.
-     *
-     * @private
-     * @param {String} methodName The name of the method to check for.
-     * @param {Object} obj The object to test.
-     * @return {Boolean} `true` has a given method, `false` otherwise.
-     * @example
-     *
-     *      var person = { name: 'John' };
-     *      person.shout = function() { alert(this.name); };
-     *
-     *      _hasMethod('shout', person); //=> true
-     *      _hasMethod('foo', person); //=> false
-     */
-    var _hasMethod = function _hasMethod(methodName, obj) {
-        return obj != null && !_isArray(obj) && typeof obj[methodName] === 'function';
+        var keysA = keys(a);
+        if (keysA.length !== keys(b).length) {
+            return false;
+        }
+        var idx = stackA.length - 1;
+        while (idx >= 0) {
+            if (stackA[idx] === a) {
+                return stackB[idx] === b;
+            }
+            idx -= 1;
+        }
+        stackA.push(a);
+        stackB.push(b);
+        idx = keysA.length - 1;
+        while (idx >= 0) {
+            var key = keysA[idx];
+            if (!(_has(key, b) && _equals(b[key], a[key], stackA, stackB))) {
+                return false;
+            }
+            idx -= 1;
+        }
+        stackA.pop();
+        stackB.pop();
+        return true;
     };
 
     /**
@@ -4067,45 +4190,6 @@
         };
     }();
 
-    var _stepCat = function () {
-        var _stepCatArray = {
-            '@@transducer/init': Array,
-            '@@transducer/step': function (xs, x) {
-                return _concat(xs, [x]);
-            },
-            '@@transducer/result': _identity
-        };
-        var _stepCatString = {
-            '@@transducer/init': String,
-            '@@transducer/step': function (a, b) {
-                return a + b;
-            },
-            '@@transducer/result': _identity
-        };
-        var _stepCatObject = {
-            '@@transducer/init': Object,
-            '@@transducer/step': function (result, input) {
-                return merge(result, isArrayLike(input) ? createMapEntry(input[0], input[1]) : input);
-            },
-            '@@transducer/result': _identity
-        };
-        return function _stepCat(obj) {
-            if (_isTransformer(obj)) {
-                return obj;
-            }
-            if (isArrayLike(obj)) {
-                return _stepCatArray;
-            }
-            if (typeof obj === 'string') {
-                return _stepCatString;
-            }
-            if (typeof obj === 'object') {
-                return _stepCatObject;
-            }
-            throw new Error('Cannot create transformer for ' + obj);
-        };
-    }();
-
     var _xall = function () {
         function XAll(f, xf) {
             this.xf = xf;
@@ -4153,6 +4237,35 @@
         };
         return _curry2(function _xany(f, xf) {
             return new XAny(f, xf);
+        });
+    }();
+
+    var _xaperture = function () {
+        function XAperture(n, xf) {
+            this.xf = xf;
+            this.pos = 0;
+            this.full = false;
+            this.acc = new Array(n);
+        }
+        XAperture.prototype['@@transducer/init'] = _xfBase.init;
+        XAperture.prototype['@@transducer/result'] = _xfBase.result;
+        XAperture.prototype['@@transducer/step'] = function (result, input) {
+            this.store(input);
+            return this.full ? this.xf['@@transducer/step'](result, this.getCopy()) : result;
+        };
+        XAperture.prototype.store = function (input) {
+            this.acc[this.pos] = input;
+            this.pos += 1;
+            if (this.pos === this.acc.length) {
+                this.pos = 0;
+                this.full = true;
+            }
+        };
+        XAperture.prototype.getCopy = function () {
+            return _concat(_slice(this.acc, this.pos), _slice(this.acc, 0, this.pos));
+        };
+        return _curry2(function _xaperture(n, xf) {
+            return new XAperture(n, xf);
         });
     }();
 
@@ -4241,6 +4354,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.15.0
      * @category Function
      * @category List
      * @sig ((a ... -> b) ... -> [a] -> *) -> (a ..., Int, [a] -> b) ... -> [a] -> *)
@@ -4249,7 +4363,7 @@
      * @example
      *
      *      var mapIndexed = R.addIndex(R.map);
-     *      mapIndexed(function(val, idx) {return idx + '-' + val;}, ['f', 'o', 'o', 'b', 'a', 'r']);
+     *      mapIndexed((val, idx) => idx + '-' + val, ['f', 'o', 'o', 'b', 'a', 'r']);
      *      //=> ['0-f', '1-o', '2-o', '3-b', '4-a', '5-r']
      */
     var addIndex = _curry1(function addIndex(fn) {
@@ -4274,11 +4388,14 @@
      * Returns `true` if all elements of the list match the predicate, `false` if there are any
      * that don't.
      *
+     * Dispatches to the `all` method of the second argument, if present.
+     *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig (a -> Boolean) -> [a] -> Boolean
      * @param {Function} fn The predicate function.
@@ -4305,39 +4422,17 @@
     }));
 
     /**
-     * A function that returns the first argument if it's falsy otherwise the second
-     * argument. Note that this is NOT short-circuited, meaning that if expressions
-     * are passed they are both evaluated.
-     *
-     * Dispatches to the `and` method of the first argument if applicable.
-     *
-     * @func
-     * @memberOf R
-     * @category Logic
-     * @sig * -> * -> *
-     * @param {*} a any value
-     * @param {*} b any other value
-     * @return {*} the first argument if falsy otherwise the second argument.
-     * @see R.both
-     * @example
-     *
-     *      R.and(false, true); //=> false
-     *      R.and(0, []); //=> 0
-     *      R.and(null, ''); => null
-     */
-    var and = _curry2(function and(a, b) {
-        return _hasMethod('and', a) ? a.and(b) : a && b;
-    });
-
-    /**
      * Returns `true` if at least one of elements of the list match the predicate, `false`
      * otherwise.
+     *
+     * Dispatches to the `any` method of the second argument, if present.
      *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig (a -> Boolean) -> [a] -> Boolean
      * @param {Function} fn The predicate function.
@@ -4364,11 +4459,37 @@
     }));
 
     /**
+     * Returns a new list, composed of n-tuples of consecutive elements
+     * If `n` is greater than the length of the list, an empty list is returned.
+     *
+     * Dispatches to the `aperture` method of the second argument, if present.
+     *
+     * Acts as a transducer if a transformer is given in list position.
+     * @see R.transduce
+     *
+     * @func
+     * @memberOf R
+     * @since v0.12.0
+     * @category List
+     * @sig Number -> [a] -> [[a]]
+     * @param {Number} n The size of the tuples to create
+     * @param {Array} list The list to split into `n`-tuples
+     * @return {Array} The new list.
+     * @example
+     *
+     *      R.aperture(2, [1, 2, 3, 4, 5]); //=> [[1, 2], [2, 3], [3, 4], [4, 5]]
+     *      R.aperture(3, [1, 2, 3, 4, 5]); //=> [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+     *      R.aperture(7, [1, 2, 3, 4, 5]); //=> []
+     */
+    var aperture = _curry2(_dispatchable('aperture', _xaperture, _aperture));
+
+    /**
      * Wraps a function of any arity (including nullary) in a function that accepts exactly 2
      * parameters. Any extraneous parameters will not be passed to the supplied function.
      *
      * @func
      * @memberOf R
+     * @since v0.2.0
      * @category Function
      * @sig (* -> c) -> (a, b -> c)
      * @param {Function} fn The function to wrap.
@@ -4392,12 +4513,13 @@
     });
 
     /**
-     * Creates a deep copy of the value which may contain (nested) `Array`s and
-     * `Object`s, `Number`s, `String`s, `Boolean`s and `Date`s. `Function`s are
-     * not copied, but assigned by their reference.
+     * Creates a deep copy of the value which may contain (nested) `Array`s and `Object`s, `Number`s,
+     * `String`s, `Boolean`s and `Date`s. `Function`s are not copied, but assigned by their
+     * reference. Dispatches to a `clone` method if present.
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Object
      * @sig {*} -> {*}
      * @param {*} value The object or array to clone
@@ -4409,39 +4531,31 @@
      *      objects[0] === objectsClone[0]; //=> false
      */
     var clone = _curry1(function clone(value) {
-        return _clone(value, [], []);
+        return value != null && typeof value.clone === 'function' ? value.clone() : _clone(value, [], []);
     });
 
     /**
-     * Returns a new list consisting of the elements of the first list followed by the elements
-     * of the second.
+     * Creates an object containing a single key:value pair.
      *
      * @func
      * @memberOf R
-     * @category List
-     * @sig [a] -> [a] -> [a]
-     * @param {Array} list1 The first list to merge.
-     * @param {Array} list2 The second set to merge.
-     * @return {Array} A new array consisting of the contents of `list1` followed by the
-     *         contents of `list2`. If, instead of an Array for `list1`, you pass an
-     *         object with a `concat` method on it, `concat` will call `list1.concat`
-     *         and pass it the value of `list2`.
-     *
+     * @since v0.7.0
+     * @category Object
+     * @sig String -> a -> {String:a}
+     * @param {String} key
+     * @param {*} val
+     * @return {Object}
+     * @see R.pair, R.objOf
+     * @deprecated since v0.18.0
      * @example
      *
-     *      R.concat([], []); //=> []
-     *      R.concat([4, 5, 6], [1, 2, 3]); //=> [4, 5, 6, 1, 2, 3]
-     *      R.concat('ABC', 'DEF'); // 'ABCDEF'
+     *      var matchPhrases = R.compose(
+     *        R.createMapEntry('must'),
+     *        R.map(R.createMapEntry('match_phrase'))
+     *      );
+     *      matchPhrases(['foo', 'bar', 'baz']); //=> {must: [{match_phrase: 'foo'}, {match_phrase: 'bar'}, {match_phrase: 'baz'}]}
      */
-    var concat = _curry2(function concat(set1, set2) {
-        if (_isArray(set2)) {
-            return _concat(set1, set2);
-        } else if (_hasMethod('concat', set1)) {
-            return set1.concat(set2);
-        } else {
-            throw new TypeError('can\'t concat ' + typeof set1);
-        }
-    });
+    var createMapEntry = objOf;
 
     /**
      * Returns a curried equivalent of the provided function. The curried
@@ -4469,6 +4583,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
      * @sig (* -> a) -> (* -> a)
      * @param {Function} fn The function to curry.
@@ -4476,9 +4591,7 @@
      * @see R.curryN
      * @example
      *
-     *      var addFourNumbers = function(a, b, c, d) {
-     *        return a + b + c + d;
-     *      };
+     *      var addFourNumbers = (a, b, c, d) => a + b + c + d;
      *
      *      var curriedAddFourNumbers = R.curry(addFourNumbers);
      *      var f = curriedAddFourNumbers(1, 2);
@@ -4494,11 +4607,14 @@
      * to the supplied predicate function, skipping elements while the predicate function returns
      * `true`. The predicate function is passed one argument: *(value)*.
      *
+     * Dispatches to the `dropWhile` method of the second argument, if present.
+     *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category List
      * @sig (a -> Boolean) -> [a] -> [a]
      * @param {Function} fn The function called per iteration.
@@ -4507,9 +4623,7 @@
      * @see R.takeWhile
      * @example
      *
-     *      var lteTwo = function(x) {
-     *        return x <= 2;
-     *      };
+     *      var lteTwo = x => x <= 2;
      *
      *      R.dropWhile(lteTwo, [1, 2, 3, 4, 3, 2, 1]); //=> [3, 4, 3, 2, 1]
      */
@@ -4526,8 +4640,11 @@
      * Dispatches to an `equals` method if present. Handles cyclical data
      * structures.
      *
+     * Dispatches to the `equals` method of both arguments, if present.
+     *
      * @func
      * @memberOf R
+     * @since v0.15.0
      * @category Relation
      * @sig a -> b -> Boolean
      * @param {*} a
@@ -4544,7 +4661,7 @@
      *      R.equals(a, b); //=> true
      */
     var equals = _curry2(function equals(a, b) {
-        return _hasMethod('equals', a) ? a.equals(b) : _hasMethod('equals', b) ? b.equals(a) : _equals(a, b, [], []);
+        return _equals(a, b, [], []);
     });
 
     /**
@@ -4555,11 +4672,14 @@
      * `Array.prototype.filter` method. For more details on this behavior, see:
      * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#Description
      *
+     * Dispatches to the `filter` method of the second argument, if present.
+     *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig (a -> Boolean) -> [a] -> [a]
      * @param {Function} fn The function called per iteration.
@@ -4568,9 +4688,8 @@
      * @see R.reject
      * @example
      *
-     *      var isEven = function(n) {
-     *        return n % 2 === 0;
-     *      };
+     *      var isEven = n => n % 2 === 0;
+     *
      *      R.filter(isEven, [1, 2, 3, 4]); //=> [2, 4]
      */
     var filter = _curry2(_dispatchable('filter', _xfilter, _filter));
@@ -4579,11 +4698,14 @@
      * Returns the first element of the list which matches the predicate, or `undefined` if no
      * element matches.
      *
+     * Dispatches to the `find` method of the second argument, if present.
+     *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig (a -> Boolean) -> [a] -> a | undefined
      * @param {Function} fn The predicate function used to determine if the element is the
@@ -4611,11 +4733,14 @@
      * Returns the index of the first element of the list which matches the predicate, or `-1`
      * if no element matches.
      *
+     * Dispatches to the `findIndex` method of the second argument, if present.
+     *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
      * @func
      * @memberOf R
+     * @since v0.1.1
      * @category List
      * @sig (a -> Boolean) -> [a] -> Number
      * @param {Function} fn The predicate function used to determine if the element is the
@@ -4644,11 +4769,14 @@
      * Returns the last element of the list which matches the predicate, or `undefined` if no
      * element matches.
      *
+     * Dispatches to the `findLast` method of the second argument, if present.
+     *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
      * @func
      * @memberOf R
+     * @since v0.1.1
      * @category List
      * @sig (a -> Boolean) -> [a] -> a | undefined
      * @param {Function} fn The predicate function used to determine if the element is the
@@ -4675,11 +4803,14 @@
      * Returns the index of the last element of the list which matches the predicate, or
      * `-1` if no element matches.
      *
+     * Dispatches to the `findLastIndex` method of the second argument, if present.
+     *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
      * @func
      * @memberOf R
+     * @since v0.1.1
      * @category List
      * @sig (a -> Boolean) -> [a] -> Number
      * @param {Function} fn The predicate function used to determine if the element is the
@@ -4709,6 +4840,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig [a] -> [b]
      * @param {Array} list The array to consider.
@@ -4727,15 +4859,14 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
      * @sig (a -> b -> c -> ... -> z) -> (b -> a -> c -> ... -> z)
      * @param {Function} fn The function to invoke with its first two parameters reversed.
      * @return {*} The result of invoking `fn` with its first two parameters' order reversed.
      * @example
      *
-     *      var mergeThree = function(a, b, c) {
-     *        return ([]).concat(a, b, c);
-     *      };
+     *      var mergeThree = (a, b, c) => [].concat(a, b, c);
      *
      *      mergeThree(1, 2, 3); //=> [1, 2, 3]
      *
@@ -4763,8 +4894,11 @@
      * Also note that, unlike `Array.prototype.forEach`, Ramda's `forEach` returns the original
      * array. In some libraries this function is named `each`.
      *
+     * Dispatches to the `forEach` method of the second argument, if present.
+     *
      * @func
      * @memberOf R
+     * @since v0.1.1
      * @category List
      * @sig (a -> *) -> [a] -> [a]
      * @param {Function} fn The function to invoke. Receives one argument, `value`.
@@ -4772,7 +4906,7 @@
      * @return {Array} The original list.
      * @example
      *
-     *      var printXPlusFive = function(x) { console.log(x + 5); };
+     *      var printXPlusFive = x => console.log(x + 5);
      *      R.forEach(printXPlusFive, [1, 2, 3]); //=> [1, 2, 3]
      *      //-> 6
      *      //-> 7
@@ -4793,10 +4927,12 @@
      *
      * @func
      * @memberOf R
+     * @since v0.4.0
      * @category Object
      * @sig {*} -> [String]
      * @param {Object} obj The objects with functions in it
      * @return {Array} A list of the object's own properties that map to functions.
+     * @deprecated since v0.18.0
      * @example
      *
      *      R.functions(R); // returns list of ramda's own function names
@@ -4813,11 +4949,13 @@
      *
      * @func
      * @memberOf R
+     * @since v0.4.0
      * @category Object
      * @sig {*} -> [String]
      * @param {Object} obj The objects with functions in it
      * @return {Array} A list of the object's own properties and prototype
      *         properties that map to functions.
+     * @deprecated since v0.18.0
      * @example
      *
      *      R.functionsIn(R); // returns list of ramda's own and prototype function names
@@ -4833,11 +4971,14 @@
      * Splits a list into sub-lists stored in an object, based on the result of calling a String-returning function
      * on each element, and grouping the results according to values returned.
      *
+     * Dispatches to the `groupBy` method of the second argument, if present.
+     *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig (a -> String) -> [a] -> {String: [a]}
      * @param {Function} fn Function :: a -> String
@@ -4879,6 +5020,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @see R.tail, R.init, R.last
      * @sig [a] -> a | Undefined
@@ -4903,6 +5045,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig (a,a -> Boolean) -> [a] -> [a] -> [a]
      * @param {Function} pred A predicate function that determines whether
@@ -4927,9 +5070,7 @@
      *        {id: 177, name: 'Neil Young'}
      *      ];
      *
-     *      var sameId = function(o1, o2) {return o1.id === o2.id;};
-     *
-     *      R.intersectionWith(sameId, buffaloSpringfield, csny);
+     *      R.intersectionWith(R.eqBy(R.prop('id')), buffaloSpringfield, csny);
      *      //=> [{id: 456, name: 'Stephen Stills'}, {id: 177, name: 'Neil Young'}]
      */
     var intersectionWith = _curry3(function intersectionWith(pred, list1, list2) {
@@ -4946,8 +5087,11 @@
     /**
      * Creates a new list with the separator interposed between elements.
      *
+     * Dispatches to the `intersperse` method of the second argument, if present.
+     *
      * @func
      * @memberOf R
+     * @since v0.14.0
      * @category List
      * @sig a -> [a] -> [a]
      * @param {*} separator The element to add to the list.
@@ -4973,50 +5117,13 @@
     }));
 
     /**
-     * Transforms the items of the list with the transducer and appends the transformed items to
-     * the accumulator using an appropriate iterator function based on the accumulator type.
-     *
-     * The accumulator can be an array, string, object or a transformer. Iterated items will
-     * be appended to arrays and concatenated to strings. Objects will be merged directly or 2-item
-     * arrays will be merged as key, value pairs.
-     *
-     * The accumulator can also be a transformer object that provides a 2-arity reducing iterator
-     * function, step, 0-arity initial value function, init, and 1-arity result extraction function
-     * result. The step function is used as the iterator function in reduce. The result function is
-     * used to convert the final accumulator into the return type and in most cases is R.identity.
-     * The init function is used to provide the initial accumulator.
-     *
-     * The iteration is performed with R.reduce after initializing the transducer.
-     *
-     * @func
-     * @memberOf R
-     * @category List
-     * @sig a -> (b -> b) -> [c] -> a
-     * @param {*} acc The initial accumulator value.
-     * @param {Function} xf The transducer function. Receives a transformer and returns a transformer.
-     * @param {Array} list The list to iterate over.
-     * @return {*} The final, accumulated value.
-     * @example
-     *
-     *      var numbers = [1, 2, 3, 4];
-     *      var transducer = R.compose(R.map(R.add(1)), R.take(2));
-     *
-     *      R.into([], transducer, numbers); //=> [2, 3]
-     *
-     *      var intoArray = R.into([]);
-     *      intoArray(transducer, numbers); //=> [2, 3]
-     */
-    var into = _curry3(function into(acc, xf, list) {
-        return _isTransformer(acc) ? _reduce(xf(acc), acc['@@transducer/init'](), list) : _reduce(xf(_stepCat(acc)), acc, list);
-    });
-
-    /**
      * Same as R.invertObj, however this accounts for objects
      * with duplicate values by putting the values into an
      * array.
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Object
      * @sig {s: x} -> {x: [ s, ... ]}
      * @param {Object} obj The object or array to invert
@@ -5049,10 +5156,14 @@
 
     /**
      * Returns a new object with the keys of the given object
-     * as values, and the values of the given object as keys.
+     * as values, and the values of the given object, which are
+     * coerced to strings, as keys.
+     * Note that the last key found is preferred when handling
+     * the same value.
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Object
      * @sig {s: x} -> {x: s}
      * @param {Object} obj The object or array to invert
@@ -5085,10 +5196,36 @@
     });
 
     /**
+     * Returns `true` if the given value is its type's empty value; `false`
+     * otherwise.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.1.0
+     * @category Logic
+     * @sig a -> Boolean
+     * @param {*} x
+     * @return {Boolean}
+     * @see R.empty
+     * @example
+     *
+     *      R.isEmpty([1, 2, 3]);   //=> false
+     *      R.isEmpty([]);          //=> true
+     *      R.isEmpty('');          //=> true
+     *      R.isEmpty(null);        //=> false
+     *      R.isEmpty({});          //=> true
+     *      R.isEmpty({length: 0}); //=> false
+     */
+    var isEmpty = _curry1(function isEmpty(x) {
+        return x != null && equals(x, empty(x));
+    });
+
+    /**
      * Returns the last element of the given list or string.
      *
      * @func
      * @memberOf R
+     * @since v0.1.4
      * @category List
      * @see R.init, R.head, R.tail
      * @sig [a] -> a | Undefined
@@ -5112,6 +5249,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig a -> [a] -> Number
      * @param {*} target The item to find.
@@ -5124,7 +5262,7 @@
      *      R.lastIndexOf(10, [1,2,3,4]); //=> -1
      */
     var lastIndexOf = _curry2(function lastIndexOf(target, xs) {
-        if (_hasMethod('lastIndexOf', xs)) {
+        if (typeof xs.lastIndexOf === 'function' && !_isArray(xs)) {
             return xs.lastIndexOf(target);
         } else {
             var idx = xs.length - 1;
@@ -5146,25 +5284,44 @@
      * native `Array.prototype.map` method. For more details on this behavior, see:
      * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#Description
      *
+     * Dispatches to the `map` method of the second argument, if present.
+     *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
+     * Map treats also treats functions as functors and will compose them together.
+     *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
-     * @sig (a -> b) -> [a] -> [b]
+     * @sig Functor f => (a -> b) -> f a -> f b
      * @param {Function} fn The function to be called on every element of the input `list`.
      * @param {Array} list The list to be iterated over.
      * @return {Array} The new list.
      * @example
      *
-     *      var double = function(x) {
-     *        return x * 2;
-     *      };
+     *      var double = x => x * 2;
      *
      *      R.map(double, [1, 2, 3]); //=> [2, 4, 6]
+     *
+     *      R.map(double, {x: 1, y: 2, z: 3}); //=> {x: 2, y: 4, z: 6}
      */
-    var map = _curry2(_dispatchable('map', _xmap, _map));
+    var map = _curry2(_dispatchable('map', _xmap, function map(fn, functor) {
+        switch (Object.prototype.toString.call(functor)) {
+        case '[object Function]':
+            return curryN(functor.length, function () {
+                return fn.call(this, functor.apply(this, arguments));
+            });
+        case '[object Object]':
+            return _reduce(function (acc, key) {
+                acc[key] = fn(functor[key]);
+                return acc;
+            }, {}, keys(functor));
+        default:
+            return _map(fn, functor);
+        }
+    }));
 
     /**
      * Map, but for objects. Creates an object with the same keys as `obj` and values
@@ -5173,6 +5330,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.4
      * @category Object
      * @sig (v -> v) -> {k: v} -> {k: v}
      * @param {Function} fn A function called for each property in `obj`. Its return value will
@@ -5180,12 +5338,11 @@
      * @param {Object} obj The object to iterate over.
      * @return {Object} A new object with the same keys as `obj` and values that are the result
      *         of running each property through `fn`.
+     * @deprecated since v0.18.0
      * @example
      *
      *      var values = { x: 1, y: 2, z: 3 };
-     *      var double = function(num) {
-     *        return num * 2;
-     *      };
+     *      var double = num => num * 2;
      *
      *      R.mapObj(double, values); //=> { x: 2, y: 4, z: 6 }
      */
@@ -5197,11 +5354,12 @@
     });
 
     /**
-     * Like `mapObj`, but but passes additional arguments to the predicate function. The
+     * Like `mapObj`, but passes additional arguments to the predicate function. The
      * predicate function is passed three arguments: *(value, key, obj)*.
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Object
      * @sig (v, k, {k: v} -> v) -> {k: v} -> {k: v}
      * @param {Function} fn A function called for each property in `obj`. Its return value will
@@ -5212,9 +5370,7 @@
      * @example
      *
      *      var values = { x: 1, y: 2, z: 3 };
-     *      var prependKeyAndDouble = function(num, key, obj) {
-     *        return key + (num * 2);
-     *      };
+     *      var prependKeyAndDouble = (num, key, obj) => key + (num * 2);
      *
      *      R.mapObjIndexed(prependKeyAndDouble, values); //=> { x: 'x2', y: 'y4', z: 'z6' }
      */
@@ -5229,8 +5385,11 @@
      * Returns `true` if no elements of the list match the predicate,
      * `false` otherwise.
      *
+     * Dispatches to the `any` method of the second argument, if present.
+     *
      * @func
      * @memberOf R
+     * @since v0.12.0
      * @category List
      * @sig (a -> Boolean) -> [a] -> Boolean
      * @param {Function} fn The predicate function.
@@ -5245,84 +5404,58 @@
     var none = _curry2(_complement(_dispatchable('any', _xany, any)));
 
     /**
-     * A function that returns the first truthy of two arguments otherwise the
-     * last argument. Note that this is NOT short-circuited, meaning that if
-     * expressions are passed they are both evaluated.
-     *
-     * Dispatches to the `or` method of the first argument if applicable.
+     * Takes a function `f` and a list of arguments, and returns a function `g`.
+     * When applied, `g` returns the result of applying `f` to the arguments
+     * provided initially followed by the arguments provided to `g`.
      *
      * @func
      * @memberOf R
-     * @category Logic
-     * @sig * -> * -> *
-     * @param {*} a any value
-     * @param {*} b any other value
-     * @return {*} the first truthy argument, otherwise the last argument.
-     * @see R.either
-     * @example
-     *
-     *      R.or(false, true); //=> true
-     *      R.or(0, []); //=> []
-     *      R.or(null, ''); => ''
-     */
-    var or = _curry2(function or(a, b) {
-        return _hasMethod('or', a) ? a.or(b) : a || b;
-    });
-
-    /**
-     * Accepts as its arguments a function and any number of values and returns a function that,
-     * when invoked, calls the original function with all of the values prepended to the
-     * original function's arguments list. In some libraries this function is named `applyLeft`.
-     *
-     * @func
-     * @memberOf R
+     * @since v0.10.0
      * @category Function
-     * @sig (a -> b -> ... -> i -> j -> ... -> m -> n) -> a -> b-> ... -> i -> (j -> ... -> m -> n)
-     * @param {Function} fn The function to invoke.
-     * @param {...*} [args] Arguments to prepend to `fn` when the returned function is invoked.
-     * @return {Function} A new function wrapping `fn`. When invoked, it will call `fn`
-     *         with `args` prepended to `fn`'s arguments list.
+     * @sig ((a, b, c, ..., n) -> x) -> [a, b, c, ...] -> ((d, e, f, ..., n) -> x)
+     * @param {Function} f
+     * @param {Array} args
+     * @return {Function}
+     * @see R.partialRight
      * @example
      *
-     *      var multiply = function(a, b) { return a * b; };
-     *      var double = R.partial(multiply, 2);
+     *      var multiply = (a, b) => a * b;
+     *      var double = R.partial(multiply, [2]);
      *      double(2); //=> 4
      *
-     *      var greet = function(salutation, title, firstName, lastName) {
-     *        return salutation + ', ' + title + ' ' + firstName + ' ' + lastName + '!';
-     *      };
-     *      var sayHello = R.partial(greet, 'Hello');
-     *      var sayHelloToMs = R.partial(sayHello, 'Ms.');
+     *      var greet = (salutation, title, firstName, lastName) =>
+     *        salutation + ', ' + title + ' ' + firstName + ' ' + lastName + '!';
+     *
+     *      var sayHello = R.partial(greet, ['Hello']);
+     *      var sayHelloToMs = R.partial(sayHello, ['Ms.']);
      *      sayHelloToMs('Jane', 'Jones'); //=> 'Hello, Ms. Jane Jones!'
      */
-    var partial = curry(_createPartialApplicator(_concat));
+    var partial = _createPartialApplicator(_concat);
 
     /**
-     * Accepts as its arguments a function and any number of values and returns a function that,
-     * when invoked, calls the original function with all of the values appended to the original
-     * function's arguments list.
-     *
-     * Note that `partialRight` is the opposite of `partial`: `partialRight` fills `fn`'s arguments
-     * from the right to the left.  In some libraries this function is named `applyRight`.
+     * Takes a function `f` and a list of arguments, and returns a function `g`.
+     * When applied, `g` returns the result of applying `f` to the arguments
+     * provided to `g` followed by the arguments provided initially.
      *
      * @func
      * @memberOf R
+     * @since v0.10.0
      * @category Function
-     * @sig (a -> b-> ... -> i -> j -> ... -> m -> n) -> j -> ... -> m -> n -> (a -> b-> ... -> i)
-     * @param {Function} fn The function to invoke.
-     * @param {...*} [args] Arguments to append to `fn` when the returned function is invoked.
-     * @return {Function} A new function wrapping `fn`. When invoked, it will call `fn` with
-     *         `args` appended to `fn`'s arguments list.
+     * @sig ((a, b, c, ..., n) -> x) -> [d, e, f, ..., n] -> ((a, b, c, ...) -> x)
+     * @param {Function} f
+     * @param {Array} args
+     * @return {Function}
+     * @see R.partial
      * @example
      *
-     *      var greet = function(salutation, title, firstName, lastName) {
-     *        return salutation + ', ' + title + ' ' + firstName + ' ' + lastName + '!';
-     *      };
-     *      var greetMsJaneJones = R.partialRight(greet, 'Ms.', 'Jane', 'Jones');
+     *      var greet = (salutation, title, firstName, lastName) =>
+     *        salutation + ', ' + title + ' ' + firstName + ' ' + lastName + '!';
+     *
+     *      var greetMsJaneJones = R.partialRight(greet, ['Ms.', 'Jane', 'Jones']);
      *
      *      greetMsJaneJones('Hello'); //=> 'Hello, Ms. Jane Jones!'
      */
-    var partialRight = curry(_createPartialApplicator(flip(_concat)));
+    var partialRight = _createPartialApplicator(flip(_concat));
 
     /**
      * Takes a predicate and a list and returns the pair of lists of
@@ -5330,6 +5463,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.4
      * @category List
      * @sig (a -> Boolean) -> [a] -> [[a],[a]]
      * @param {Function} pred A predicate to determine which array the element belongs to.
@@ -5358,6 +5492,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.7.0
      * @category Relation
      * @sig [String] -> * -> {String: *} -> Boolean
      * @param {Array} path The path of the nested property to use
@@ -5383,11 +5518,13 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig k -> [{k: v}] -> [v]
      * @param {Number|String} key The key name to pluck off of each object.
      * @param {Array} list The array to consider.
      * @return {Array} The list of values for the given key.
+     * @see R.props
      * @example
      *
      *      R.pluck('a')([{a: 1}, {a: 2}]); //=> [1, 2]
@@ -5403,6 +5540,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig String -> a -> Object -> Boolean
      * @param {String} name
@@ -5430,6 +5568,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.16.0
      * @category Type
      * @sig Type -> String -> Object -> Boolean
      * @param {Function} type
@@ -5461,8 +5600,11 @@
      * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#Description
      * @see R.reduced
      *
+     * Dispatches to the `reduce` method of the third argument, if present.
+     *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig (a,b -> a) -> a -> [b] -> a
      * @param {Function} fn The iterator function. Receives two values, the accumulator and the
@@ -5473,9 +5615,7 @@
      * @example
      *
      *      var numbers = [1, 2, 3];
-     *      var add = function(a, b) {
-     *        return a + b;
-     *      };
+     *      var add = (a, b) => a + b;
      *
      *      R.reduce(add, 10, numbers); //=> 16
      */
@@ -5490,6 +5630,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig (a -> Boolean) -> [a] -> [a]
      * @param {Function} fn The function called per iteration.
@@ -5498,9 +5639,8 @@
      * @see R.filter
      * @example
      *
-     *      var isOdd = function(n) {
-     *        return n % 2 === 1;
-     *      };
+     *      var isOdd = (n) => n % 2 === 1;
+     *
      *      R.reject(isOdd, [1, 2, 3, 4]); //=> [2, 4]
      */
     var reject = _curry2(function reject(fn, list) {
@@ -5512,6 +5652,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.1
      * @category List
      * @sig a -> n -> [a]
      * @param {*} value The value to repeat.
@@ -5533,8 +5674,11 @@
      * Returns the elements of the given list or string (or object with a `slice`
      * method) from `fromIndex` (inclusive) to `toIndex` (exclusive).
      *
+     * Dispatches to the `slice` method of the third argument, if present.
+     *
      * @func
      * @memberOf R
+     * @since v0.1.4
      * @category List
      * @sig Number -> Number -> [a] -> [a]
      * @sig Number -> Number -> String -> String
@@ -5559,6 +5703,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.16.0
      * @category List
      * @sig Number -> [a] -> [[a]]
      * @sig Number -> String -> [String]
@@ -5587,6 +5732,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Math
      * @sig [Number] -> Number
      * @param {Array} list An array of numbers
@@ -5602,8 +5748,11 @@
      * Returns all but the first element of the given list or string (or object
      * with a `tail` method).
      *
+     * Dispatches to the `slice` method of the first argument, if present.
+     *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @see R.head, R.init, R.last
      * @sig [a] -> [a]
@@ -5628,8 +5777,11 @@
      * Returns the first `n` elements of the given list, string, or
      * transducer/transformer (or object with a `take` method).
      *
+     * Dispatches to the `take` method of the second argument, if present.
+     *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig Number -> [a] -> [a]
      * @sig Number -> String -> String
@@ -5670,11 +5822,14 @@
      * `false`. Excludes the element that caused the predicate function to fail. The predicate
      * function is passed one argument: *(value)*.
      *
+     * Dispatches to the `takeWhile` method of the second argument, if present.
+     *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig (a -> Boolean) -> [a] -> [a]
      * @param {Function} fn The function called per iteration.
@@ -5683,9 +5838,7 @@
      * @see R.dropWhile
      * @example
      *
-     *      var isNotFour = function(x) {
-     *        return !(x === 4);
-     *      };
+     *      var isNotFour = x => x !== 4;
      *
      *      R.takeWhile(isNotFour, [1, 2, 3, 4]); //=> [1, 2, 3]
      */
@@ -5721,6 +5874,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.12.0
      * @category List
      * @see R.reduce, R.reduced, R.into
      * @sig (c -> c) -> (a,b -> a) -> a -> [b] -> a
@@ -5748,6 +5902,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig (a,a -> Boolean) -> [a] -> [a] -> [a]
      * @param {Function} pred A predicate used to test whether two items are equal.
@@ -5758,10 +5913,9 @@
      * @see R.union
      * @example
      *
-     *      function cmp(x, y) { return x.a === y.a; }
      *      var l1 = [{a: 1}, {a: 2}];
      *      var l2 = [{a: 1}, {a: 4}];
-     *      R.unionWith(cmp, l1, l2); //=> [{a: 1}, {a: 2}, {a: 4}]
+     *      R.unionWith(R.eqBy(R.prop('a')), l1, l2); //=> [{a: 1}, {a: 2}, {a: 4}]
      */
     var unionWith = _curry3(function unionWith(pred, list1, list2) {
         return uniqWith(pred, _concat(list1, list2));
@@ -5773,6 +5927,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig [a] -> [a]
      * @param {Array} list The array to consider.
@@ -5786,25 +5941,7 @@
     var uniq = uniqWith(equals);
 
     /**
-     * Returns a new list by pulling every item at the first level of nesting out, and putting
-     * them in a new array.
-     *
-     * @func
-     * @memberOf R
-     * @category List
-     * @sig [a] -> [b]
-     * @param {Array} list The array to consider.
-     * @return {Array} The flattened list.
-     * @see R.flatten
-     * @example
-     *
-     *      R.unnest([1, [2], [[3]]]); //=> [1, 2, [3]]
-     *      R.unnest([[1, 2], [3, 4], [5, 6]]); //=> [1, 2, 3, 4, 5, 6]
-     */
-    var unnest = _curry1(_makeFlat(false));
-
-    /**
-     * Accepts a function `fn` and any number of transformer functions and returns a new
+     * Accepts a function `fn` and a list of transformer functions and returns a new curried
      * function. When the new function is invoked, it calls the function `fn` with parameters
      * consisting of the result of calling each supplied handler on successive arguments to the
      * new function.
@@ -5816,50 +5953,27 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
-     * @sig (x1 -> x2 -> ... -> z) -> ((a -> x1), (b -> x2), ...) -> (a -> b -> ... -> z)
+     * @sig (x1 -> x2 -> ... -> z) -> [(a -> x1), (b -> x2), ...] -> (a -> b -> ... -> z)
      * @param {Function} fn The function to wrap.
-     * @param {...Function} transformers A variable number of transformer functions
+     * @param {Array} transformers A list of transformer functions
      * @return {Function} The wrapped function.
      * @example
      *
-     *      var double = function(y) { return y * 2; };
-     *      var square = function(x) { return x * x; };
-     *      var add = function(a, b) { return a + b; };
-     *      // Adds any number of arguments together
-     *      var addAll = function() {
-     *        return R.reduce(add, 0, arguments);
-     *      };
-     *
-     *      // Basic example
-     *      var addDoubleAndSquare = R.useWith(addAll, double, square);
-     *
-     *      //≅ addAll(double(10), square(5));
-     *      addDoubleAndSquare(10, 5); //=> 45
-     *
-     *      // Example of passing more arguments than transformers
-     *      //≅ addAll(double(10), square(5), 100);
-     *      addDoubleAndSquare(10, 5, 100); //=> 145
-     *
-     *      // If there are extra _expected_ arguments that don't need to be transformed, although
-     *      // you can ignore them, it might be best to pass in the identity function so that the new
-     *      // function correctly reports arity.
-     *      var addDoubleAndSquareWithExtraParams = R.useWith(addAll, double, square, R.identity);
-     *      // addDoubleAndSquareWithExtraParams.length //=> 3
-     *      //≅ addAll(double(10), square(5), R.identity(100));
-     *      addDoubleAndSquare(10, 5, 100); //=> 145
+     *      R.useWith(Math.pow, [R.identity, R.identity])(3, 4); //=> 81
+     *      R.useWith(Math.pow, [R.identity, R.identity])(3)(4); //=> 81
+     *      R.useWith(Math.pow, [R.dec, R.inc])(3, 4); //=> 32
+     *      R.useWith(Math.pow, [R.dec, R.inc])(3)(4); //=> 32
      */
-    /*, transformers */
-    var useWith = curry(function useWith(fn) {
-        var transformers = _slice(arguments, 1);
-        var tlen = transformers.length;
-        return curry(_arity(tlen, function () {
+    var useWith = _curry2(function useWith(fn, transformers) {
+        return curry(_arity(transformers.length, function () {
             var args = [], idx = 0;
-            while (idx < tlen) {
-                args[idx] = transformers[idx](arguments[idx]);
+            while (idx < transformers.length) {
+                args.push(transformers[idx].call(this, arguments[idx]));
                 idx += 1;
             }
-            return fn.apply(this, args.concat(_slice(arguments, tlen)));
+            return fn.apply(this, args.concat(_slice(arguments, transformers.length)));
         }));
     });
 
@@ -5873,6 +5987,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.14.0
      * @category Object
      * @sig {String: *} -> {String: *} -> Boolean
      * @param {Object} spec
@@ -5931,83 +6046,164 @@
         return -1;
     };
 
-    /**
-     * Create a predicate wrapper which will call a pick function (all/any) for each predicate
-     *
-     * @private
-     * @see R.all
-     * @see R.any
-     */
-    // Call function immediately if given arguments
-    // Return a function which will call the predicates with the provided arguments
-    var _predicateWrap = function _predicateWrap(predPicker) {
-        return function (preds) {
-            var predIterator = function () {
-                var args = arguments;
-                return predPicker(function (predicate) {
-                    return predicate.apply(null, args);
-                }, preds);
-            };
-            return arguments.length > 1 ? // Call function immediately if given arguments
-            predIterator.apply(null, _slice(arguments, 1)) : // Return a function which will call the predicates with the provided arguments
-            _arity(Math.max.apply(Math, pluck('length', preds)), predIterator);
+    var _stepCat = function () {
+        var _stepCatArray = {
+            '@@transducer/init': Array,
+            '@@transducer/step': function (xs, x) {
+                return _concat(xs, [x]);
+            },
+            '@@transducer/result': _identity
         };
-    };
+        var _stepCatString = {
+            '@@transducer/init': String,
+            '@@transducer/step': function (a, b) {
+                return a + b;
+            },
+            '@@transducer/result': _identity
+        };
+        var _stepCatObject = {
+            '@@transducer/init': Object,
+            '@@transducer/step': function (result, input) {
+                return merge(result, isArrayLike(input) ? createMapEntry(input[0], input[1]) : input);
+            },
+            '@@transducer/result': _identity
+        };
+        return function _stepCat(obj) {
+            if (_isTransformer(obj)) {
+                return obj;
+            }
+            if (isArrayLike(obj)) {
+                return _stepCatArray;
+            }
+            if (typeof obj === 'string') {
+                return _stepCatString;
+            }
+            if (typeof obj === 'object') {
+                return _stepCatObject;
+            }
+            throw new Error('Cannot create transformer for ' + obj);
+        };
+    }();
 
     var _xchain = _curry2(function _xchain(f, xf) {
         return map(f, _flatCat(xf));
     });
 
     /**
-     * Given a list of predicates, returns a new predicate that will be true exactly when all of them are.
+     * Takes a list of predicates and returns a predicate that returns true
+     * for a given list of arguments if every one of the provided predicates
+     * is satisfied by those arguments.
+     *
+     * The function returned is a curried function whose arity matches that of
+     * the highest-arity predicate.
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Logic
      * @sig [(*... -> Boolean)] -> (*... -> Boolean)
-     * @param {Array} list An array of predicate functions
-     * @param {*} optional Any arguments to pass into the predicates
-     * @return {Function} a function that applies its arguments to each of
-     *         the predicates, returning `true` if all are satisfied.
+     * @param {Array} preds
+     * @return {Function}
      * @see R.anyPass
      * @example
      *
-     *      var gt10 = function(x) { return x > 10; };
-     *      var even = function(x) { return x % 2 === 0};
-     *      var f = R.allPass([gt10, even]);
-     *      f(11); //=> false
-     *      f(12); //=> true
+     *      var isQueen = R.propEq('rank', 'Q');
+     *      var isSpade = R.propEq('suit', '♠︎');
+     *      var isQueenOfSpades = R.allPass([isQueen, isSpade]);
+     *
+     *      isQueenOfSpades({rank: 'Q', suit: '♣︎'}); //=> false
+     *      isQueenOfSpades({rank: 'Q', suit: '♠︎'}); //=> true
      */
-    var allPass = _curry1(_predicateWrap(all));
+    var allPass = _curry1(function allPass(preds) {
+        return curryN(reduce(max, 0, pluck('length', preds)), function () {
+            var idx = 0;
+            var len = preds.length;
+            while (idx < len) {
+                if (!preds[idx].apply(this, arguments)) {
+                    return false;
+                }
+                idx += 1;
+            }
+            return true;
+        });
+    });
 
     /**
-     * Given a list of predicates returns a new predicate that will be true exactly when any one of them is.
+     * Returns `true` if all elements are unique, in `R.equals` terms,
+     * otherwise `false`.
      *
      * @func
      * @memberOf R
+     * @since v0.18.0
+     * @category List
+     * @sig [a] -> Boolean
+     * @param {Array} list The array to consider.
+     * @return {Boolean} `true` if all elements are unique, else `false`.
+     * @example
+     *
+     *      R.allUniq(['1', 1]); //=> true
+     *      R.allUniq([1, 1]);   //=> false
+     *      R.allUniq([[42], [42]]); //=> false
+     */
+    var allUniq = _curry1(function allUniq(list) {
+        var len = list.length;
+        var idx = 0;
+        while (idx < len) {
+            if (_indexOf(list, list[idx], idx + 1) >= 0) {
+                return false;
+            }
+            idx += 1;
+        }
+        return true;
+    });
+
+    /**
+     * Takes a list of predicates and returns a predicate that returns true for
+     * a given list of arguments if at least one of the provided predicates is
+     * satisfied by those arguments.
+     *
+     * The function returned is a curried function whose arity matches that of
+     * the highest-arity predicate.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.9.0
      * @category Logic
      * @sig [(*... -> Boolean)] -> (*... -> Boolean)
-     * @param {Array} list An array of predicate functions
-     * @param {*} optional Any arguments to pass into the predicates
-     * @return {Function} A function that applies its arguments to each of the predicates, returning
-     *         `true` if all are satisfied.
+     * @param {Array} preds
+     * @return {Function}
      * @see R.allPass
      * @example
      *
-     *      var gt10 = function(x) { return x > 10; };
-     *      var even = function(x) { return x % 2 === 0};
-     *      var f = R.anyPass([gt10, even]);
-     *      f(11); //=> true
-     *      f(8); //=> true
-     *      f(9); //=> false
+     *      var gte = R.anyPass([R.gt, R.equals]);
+     *
+     *      gte(3, 2); //=> true
+     *      gte(2, 2); //=> true
+     *      gte(2, 3); //=> false
      */
-    var anyPass = _curry1(_predicateWrap(any));
+    var anyPass = _curry1(function anyPass(preds) {
+        return curryN(reduce(max, 0, pluck('length', preds)), function () {
+            var idx = 0;
+            var len = preds.length;
+            while (idx < len) {
+                if (preds[idx].apply(this, arguments)) {
+                    return true;
+                }
+                idx += 1;
+            }
+            return false;
+        });
+    });
 
     /**
      * ap applies a list of functions to a list of values.
      *
+     * Dispatches to the `ap` method of the second argument, if present. Also treats
+     * functions as applicatives.
+     *
      * @func
      * @memberOf R
+     * @since v0.3.0
      * @category Function
      * @sig [f] -> [a] -> [f a]
      * @param {Array} fns An array of functions
@@ -6017,10 +6213,14 @@
      *
      *      R.ap([R.multiply(2), R.add(3)], [1,2,3]); //=> [2, 4, 6, 4, 5, 6]
      */
-    var ap = _curry2(function ap(fns, vs) {
-        return _hasMethod('ap', fns) ? fns.ap(vs) : _reduce(function (acc, fn) {
-            return _concat(acc, map(fn, vs));
-        }, [], fns);
+    // else
+    var ap = _curry2(function ap(applicative, fn) {
+        return typeof applicative.ap === 'function' ? applicative.ap(fn) : typeof applicative === 'function' ? curryN(Math.max(applicative.length, fn.length), function () {
+            return applicative.apply(this, arguments)(fn.apply(this, arguments));
+        }) : // else
+        _reduce(function (acc, f) {
+            return _concat(acc, map(f, fn));
+        }, [], applicative);
     });
 
     /**
@@ -6031,6 +6231,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category Function
      * @sig (*... -> a),*... -> a
      * @param {Function} fn The function to apply to the remaining arguments.
@@ -6055,12 +6256,13 @@
 
     /**
      * `chain` maps a function over a list and concatenates the results.
-     * This implementation is compatible with the
-     * Fantasy-land Chain spec, and will work with types that implement that spec.
      * `chain` is also known as `flatMap` in some libraries
+     *
+     * Dispatches to the `chain` method of the second argument, if present.
      *
      * @func
      * @memberOf R
+     * @since v0.3.0
      * @category List
      * @sig (a -> [b]) -> [a] -> [b]
      * @param {Function} fn
@@ -6068,13 +6270,16 @@
      * @return {Array}
      * @example
      *
-     *      var duplicate = function(n) {
-     *        return [n, n];
-     *      };
+     *      var duplicate = n => [n, n];
      *      R.chain(duplicate, [1, 2, 3]); //=> [1, 1, 2, 2, 3, 3]
      */
-    var chain = _curry2(_dispatchable('chain', _xchain, function chain(fn, list) {
-        return unnest(map(fn, list));
+    var chain = _curry2(_dispatchable('chain', _xchain, function chain(fn, monad) {
+        if (typeof monad === 'function') {
+            return function () {
+                return monad.call(this, fn.apply(this, arguments)).apply(this, arguments);
+            };
+        }
+        return _makeFlat(false)(map(fn, monad));
     }));
 
     /**
@@ -6083,26 +6288,34 @@
      *
      * @func
      * @memberOf R
+     * @since v0.8.0
      * @category List
      * @see R.commute
-     * @sig Functor f => (f a -> f b) -> (x -> f x) -> [f a] -> f [b]
+     * @sig Functor f => (a -> f b) -> (x -> f x) -> [a] -> f [b]
      * @param {Function} fn The transformation function
      * @param {Function} of A function that returns the data type to return
      * @param {Array} list An array of functors of the same type
      * @return {*}
      * @example
      *
-     *      R.commuteMap(R.map(R.add(10)), R.of, [[1], [2, 3]]);   //=> [[11, 12], [11, 13]]
-     *      R.commuteMap(R.map(R.add(10)), R.of, [[1, 2], [3]]);   //=> [[11, 13], [12, 13]]
-     *      R.commuteMap(R.map(R.add(10)), R.of, [[1], [2], [3]]); //=> [[11, 12, 13]]
-     *      R.commuteMap(R.map(R.add(10)), Maybe.of, [Just(1), Just(2), Just(3)]);   //=> Just([11, 12, 13])
-     *      R.commuteMap(R.map(R.add(10)), Maybe.of, [Just(1), Just(2), Nothing()]); //=> Nothing()
+     *      var add10 = R.map(R.add(10));
+     *      R.commuteMap(add10, R.of, [[1], [2, 3]]);   //=> [[11, 12], [11, 13]]
+     *      R.commuteMap(add10, R.of, [[1, 2], [3]]);   //=> [[11, 13], [12, 13]]
+     *      R.commuteMap(add10, R.of, [[1], [2], [3]]); //=> [[11, 12, 13]]
+     *      R.commuteMap(add10, Maybe.of, [Just(1), Just(2), Just(3)]);   //=> Just([11, 12, 13])
+     *      R.commuteMap(add10, Maybe.of, [Just(1), Just(2), Nothing()]); //=> Nothing()
+     *
+     *      var fetch = url => Future((rej, res) => http.get(url, res).on('error', rej));
+     *      R.commuteMap(fetch, Future.of, [
+     *        'http://ramdajs.com',
+     *        'http://github.com/ramda'
+     *      ]); //=> Future([IncomingMessage, IncomingMessage])
      */
     var commuteMap = _curry3(function commuteMap(fn, of, list) {
-        function consF(acc, ftor) {
-            return ap(map(append, fn(ftor)), acc);
+        function consF(acc, x) {
+            return ap(map(prepend, fn(x)), acc);
         }
-        return _reduce(consF, of([]), list);
+        return reduceRight(consF, of([]), list);
     });
 
     /**
@@ -6112,6 +6325,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.4.0
      * @category Function
      * @sig Number -> (* -> {*}) -> (* -> {*})
      * @param {Number} n The arity of the constructor function.
@@ -6120,7 +6334,7 @@
      * @example
      *
      *      // Variadic constructor function
-     *      var Widget = function() {
+     *      var Widget = () => {
      *        this.children = Array.prototype.slice.call(arguments);
      *        // ...
      *      };
@@ -6168,33 +6382,33 @@
     });
 
     /**
-     * Accepts at least three functions and returns a new function. When invoked, this new
-     * function will invoke the first function, `after`, passing as its arguments the
-     * results of invoking the subsequent functions with whatever arguments are passed to
-     * the new function.
+     * Accepts a converging function and a list of branching functions and returns a new function.
+     * When invoked, this new function is applied to some arguments, each branching
+     * function is applied to those same arguments. The results of each branching
+     * function are passed as arguments to the converging function to produce the return value.
      *
      * @func
      * @memberOf R
+     * @since v0.4.2
      * @category Function
-     * @sig (x1 -> x2 -> ... -> z) -> ((a -> b -> ... -> x1), (a -> b -> ... -> x2), ...) -> (a -> b -> ... -> z)
+     * @sig (x1 -> x2 -> ... -> z) -> [(a -> b -> ... -> x1), (a -> b -> ... -> x2), ...] -> (a -> b -> ... -> z)
      * @param {Function} after A function. `after` will be invoked with the return values of
      *        `fn1` and `fn2` as its arguments.
-     * @param {...Function} functions A variable number of functions.
+     * @param {Array} functions A list of functions.
      * @return {Function} A new function.
      * @example
      *
-     *      var add = function(a, b) { return a + b; };
-     *      var multiply = function(a, b) { return a * b; };
-     *      var subtract = function(a, b) { return a - b; };
+     *      var add = (a, b) => a + b;
+     *      var multiply = (a, b) => a * b;
+     *      var subtract = (a, b) => a - b;
      *
      *      //≅ multiply( add(1, 2), subtract(1, 2) );
-     *      R.converge(multiply, add, subtract)(1, 2); //=> -3
+     *      R.converge(multiply, [add, subtract])(1, 2); //=> -3
      *
-     *      var add3 = function(a, b, c) { return a + b + c; };
-     *      R.converge(add3, multiply, add, subtract)(1, 2); //=> 4
+     *      var add3 = (a, b, c) => a + b + c;
+     *      R.converge(add3, [multiply, add, subtract])(1, 2); //=> 4
      */
-    var converge = curryN(3, function converge(after) {
-        var fns = _slice(arguments, 1);
+    var converge = _curry2(function converge(after, fns) {
         return curryN(Math.max.apply(Math, pluck('length', fns)), function () {
             var args = arguments;
             var context = this;
@@ -6208,8 +6422,11 @@
      * Returns all but the first `n` elements of the given list, string, or
      * transducer/transformer (or object with a `drop` method).
      *
+     * Dispatches to the `drop` method of the second argument, if present.
+     *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @see R.transduce
      * @sig Number -> [a] -> [a]
@@ -6235,6 +6452,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.16.0
      * @category List
      * @sig Number -> [a] -> [a]
      * @sig Number -> String -> String
@@ -6259,11 +6477,14 @@
      * determined by applying the supplied predicate two consecutive elements.
      * The first element in a series of equal element is the one being preserved.
      *
+     * Dispatches to the `dropRepeatsWith` method of the second argument, if present.
+     *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
      * @func
      * @memberOf R
+     * @since v0.14.0
      * @category List
      * @sig (a, a -> Boolean) -> [a] -> [a]
      * @param {Function} pred A predicate used to test whether two items are equal.
@@ -6271,9 +6492,9 @@
      * @return {Array} `list` without repeating elements.
      * @example
      *
-     *      function lengthEq(x, y) { return Math.abs(x) === Math.abs(y); };
+     *      var lengthEq = (x, y) => Math.abs(x) === Math.abs(y);
      *      var l = [1, -1, 1, 3, 4, -4, -4, -5, 5, 3, 3];
-     *      R.dropRepeatsWith(lengthEq, l); //=> [1, 3, 4, -5, 3]
+     *      R.dropRepeatsWith(R.eqBy(Math.abs), l); //=> [1, 3, 4, -5, 3]
      */
     var dropRepeatsWith = _curry2(_dispatchable('dropRepeatsWith', _xdropRepeatsWith, function dropRepeatsWith(pred, list) {
         var result = [];
@@ -6292,11 +6513,33 @@
     }));
 
     /**
+     * Takes a function and two values in its domain and returns `true` if
+     * the values map to the same value in the codomain; `false` otherwise.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.18.0
+     * @category Relation
+     * @sig (a -> b) -> a -> a -> Boolean
+     * @param {Function} f
+     * @param {*} x
+     * @param {*} y
+     * @return {Boolean}
+     * @example
+     *
+     *      R.eqBy(Math.abs, 5, -5); //=> true
+     */
+    var eqBy = _curry3(function eqBy(f, x, y) {
+        return equals(f(x), f(y));
+    });
+
+    /**
      * Reports whether two objects have the same value, in `R.equals` terms,
      * for the specified property. Useful as a curried predicate.
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Object
      * @sig k -> {k: v} -> {k: v} -> Boolean
      * @param {String} prop The name of the property to compare
@@ -6322,6 +6565,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig a -> [a] -> Number
      * @param {*} target The item to find.
@@ -6334,7 +6578,7 @@
      *      R.indexOf(10, [1,2,3,4]); //=> -1
      */
     var indexOf = _curry2(function indexOf(target, xs) {
-        return _hasMethod('indexOf', xs) ? xs.indexOf(target) : _indexOf(xs, target, 0);
+        return typeof xs.indexOf === 'function' && !_isArray(xs) ? xs.indexOf(target) : _indexOf(xs, target, 0);
     });
 
     /**
@@ -6342,6 +6586,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category List
      * @see R.last, R.head, R.tail
      * @sig [a] -> [a]
@@ -6363,32 +6608,64 @@
     var init = slice(0, -1);
 
     /**
+     * Transforms the items of the list with the transducer and appends the transformed items to
+     * the accumulator using an appropriate iterator function based on the accumulator type.
+     *
+     * The accumulator can be an array, string, object or a transformer. Iterated items will
+     * be appended to arrays and concatenated to strings. Objects will be merged directly or 2-item
+     * arrays will be merged as key, value pairs.
+     *
+     * The accumulator can also be a transformer object that provides a 2-arity reducing iterator
+     * function, step, 0-arity initial value function, init, and 1-arity result extraction function
+     * result. The step function is used as the iterator function in reduce. The result function is
+     * used to convert the final accumulator into the return type and in most cases is R.identity.
+     * The init function is used to provide the initial accumulator.
+     *
+     * The iteration is performed with R.reduce after initializing the transducer.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.12.0
+     * @category List
+     * @sig a -> (b -> b) -> [c] -> a
+     * @param {*} acc The initial accumulator value.
+     * @param {Function} xf The transducer function. Receives a transformer and returns a transformer.
+     * @param {Array} list The list to iterate over.
+     * @return {*} The final, accumulated value.
+     * @example
+     *
+     *      var numbers = [1, 2, 3, 4];
+     *      var transducer = R.compose(R.map(R.add(1)), R.take(2));
+     *
+     *      R.into([], transducer, numbers); //=> [2, 3]
+     *
+     *      var intoArray = R.into([]);
+     *      intoArray(transducer, numbers); //=> [2, 3]
+     */
+    var into = _curry3(function into(acc, xf, list) {
+        return _isTransformer(acc) ? _reduce(xf(acc), acc['@@transducer/init'](), list) : _reduce(xf(_stepCat(acc)), acc, list);
+    });
+
+    /**
      * Returns `true` if all elements are unique, in `R.equals` terms,
      * otherwise `false`.
      *
      * @func
      * @memberOf R
+     * @since v0.1.1
      * @category List
      * @sig [a] -> Boolean
      * @param {Array} list The array to consider.
      * @return {Boolean} `true` if all elements are unique, else `false`.
+     * @see R.allUniq
+     * @deprecated since v0.18.0
      * @example
      *
      *      R.isSet(['1', 1]); //=> true
      *      R.isSet([1, 1]);   //=> false
      *      R.isSet([[42], [42]]); //=> false
      */
-    var isSet = _curry1(function isSet(list) {
-        var len = list.length;
-        var idx = 0;
-        while (idx < len) {
-            if (_indexOf(list, list[idx], idx + 1) >= 0) {
-                return false;
-            }
-            idx += 1;
-        }
-        return true;
-    });
+    var isSet = allUniq;
 
     /**
      * Returns a lens for the given getter and setter functions. The getter "gets"
@@ -6397,6 +6674,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.8.0
      * @category Object
      * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
      * @sig (s -> a) -> ((a, s) -> s) -> Lens s a
@@ -6427,6 +6705,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.14.0
      * @category Object
      * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
      * @sig Number -> Lens s a
@@ -6450,6 +6729,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.14.0
      * @category Object
      * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
      * @sig String -> Lens s a
@@ -6474,6 +6754,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.7.0
      * @see R.lift
      * @category Function
      * @sig Number -> (*... -> *) -> ([*]... -> [*])
@@ -6481,9 +6762,7 @@
      * @return {Function} The function `fn` applicable to mappable objects.
      * @example
      *
-     *      var madd3 = R.liftN(3, R.curryN(3, function() {
-     *        return R.reduce(R.add, 0, arguments);
-     *      }));
+     *      var madd3 = R.liftN(3, R.curryN(3, () => R.reduce(R.add, 0, arguments)));
      *      madd3([1,2,3], [1,2,3], [1]); //=> [3, 4, 5, 4, 5, 6, 5, 6, 7]
      */
     var liftN = _curry2(function liftN(arity, fn) {
@@ -6498,6 +6777,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.14.0
      * @category Math
      * @sig [Number] -> Number
      * @param {Array} list
@@ -6516,6 +6796,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.14.0
      * @category Math
      * @sig [Number] -> Number
      * @param {Array} list
@@ -6543,6 +6824,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.10.0
      * @category List
      * @sig [{k: v}] -> {k: v}
      * @param {Array} list An array of objects
@@ -6565,8 +6847,9 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
-     * @sig (((a, b, ..., n) -> o), (o -> p), ..., (x -> y), (y -> z)) -> (a -> b -> ... -> n -> z)
+     * @sig (((a, b, ..., n) -> o), (o -> p), ..., (x -> y), (y -> z)) -> ((a, b, ..., n) -> z)
      * @param {...Function} functions
      * @return {Function}
      * @see R.compose
@@ -6580,7 +6863,7 @@
         if (arguments.length === 0) {
             throw new Error('pipe requires at least one argument');
         }
-        return curryN(arguments[0].length, reduce(_pipe, arguments[0], tail(arguments)));
+        return _arity(arguments[0].length, reduce(_pipe, arguments[0], tail(arguments)));
     };
 
     /**
@@ -6590,6 +6873,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.10.0
      * @category Function
      * @sig ((a -> Promise b), (b -> Promise c), ..., (y -> Promise z)) -> (a -> Promise z)
      * @param {...Function} functions
@@ -6604,7 +6888,7 @@
         if (arguments.length === 0) {
             throw new Error('pipeP requires at least one argument');
         }
-        return curryN(arguments[0].length, reduce(_pipeP, arguments[0], tail(arguments)));
+        return _arity(arguments[0].length, reduce(_pipeP, arguments[0], tail(arguments)));
     };
 
     /**
@@ -6612,6 +6896,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Math
      * @sig [Number] -> Number
      * @param {Array} list An array of numbers
@@ -6628,6 +6913,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Object
      * @category Relation
      * @sig [k] -> [{k: v}] -> [{k: v}]
@@ -6642,7 +6928,10 @@
      *      R.project(['name', 'grade'], kids); //=> [{name: 'Abby', grade: 2}, {name: 'Fred', grade: 7}]
      */
     // passing `identity` gives correct arity
-    var project = useWith(_map, pickAll, identity);
+    var project = useWith(_map, [
+        pickAll,
+        identity
+    ]);
 
     /**
      * Returns a new list containing the last `n` elements of the given list.
@@ -6650,6 +6939,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.16.0
      * @category List
      * @sig Number -> [a] -> [a]
      * @sig Number -> String -> String
@@ -6660,7 +6950,7 @@
      * @example
      *
      *      R.takeLast(1, ['foo', 'bar', 'baz']); //=> ['baz']
-     *      R.takeLast(2, ['foo', 'bar', 'baz']); //=> ['for', 'baz']
+     *      R.takeLast(2, ['foo', 'bar', 'baz']); //=> ['bar', 'baz']
      *      R.takeLast(3, ['foo', 'bar', 'baz']); //=> ['foo', 'bar', 'baz']
      *      R.takeLast(4, ['foo', 'bar', 'baz']); //=> ['foo', 'bar', 'baz']
      *      R.takeLast(3, 'ramda');               //=> 'mda'
@@ -6668,6 +6958,25 @@
     var takeLast = _curry2(function takeLast(n, xs) {
         return drop(n >= 0 ? xs.length - n : 0, xs);
     });
+
+    /**
+     * Shorthand for `R.chain(R.identity)`, which removes one level of nesting
+     * from any [Chain](https://github.com/fantasyland/fantasy-land#chain).
+     *
+     * @func
+     * @memberOf R
+     * @since v0.3.0
+     * @category List
+     * @sig Chain c => c (c a) -> c a
+     * @param {*} list
+     * @return {*}
+     * @see R.flatten, R.chain
+     * @example
+     *
+     *      R.unnest([1, [2], [[3]]]); //=> [1, 2, [3]]
+     *      R.unnest([[1, 2], [3, 4], [5, 6]]); //=> [1, 2, 3, 4, 5, 6]
+     */
+    var unnest = chain(_identity);
 
     var _contains = function _contains(a, list) {
         return _indexOf(list, a, 0) >= 0;
@@ -6690,7 +6999,9 @@
         case '[object Arguments]':
             return '(function() { return arguments; }(' + _map(recur, x).join(', ') + '))';
         case '[object Array]':
-            return '[' + _map(recur, x).concat(mapPairs(x, reject(test(/^\d+$/), keys(x)))).join(', ') + ']';
+            return '[' + _map(recur, x).concat(mapPairs(x, reject(function (k) {
+                return /^\d+$/.test(k);
+            }, keys(x)))).join(', ') + ']';
         case '[object Boolean]':
             return typeof x === 'object' ? 'new Boolean(' + recur(x.valueOf()) + ')' : x.toString();
         case '[object Date]':
@@ -6714,6 +7025,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.8.0
      * @category List
      * @see R.commuteMap
      * @sig Functor f => (x -> f x) -> [f a] -> f [a]
@@ -6736,8 +7048,9 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
-     * @sig ((y -> z), (x -> y), ..., (o -> p), ((a, b, ..., n) -> o)) -> (a -> b -> ... -> n -> z)
+     * @sig ((y -> z), (x -> y), ..., (o -> p), ((a, b, ..., n) -> o)) -> ((a, b, ..., n) -> z)
      * @param {...Function} functions
      * @return {Function}
      * @see R.pipe
@@ -6762,6 +7075,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.16.0
      * @category Function
      * @see R.pipeK
      * @sig Chain m => ((y -> m z), (x -> m y), ..., (a -> m b)) -> (m a -> m z)
@@ -6787,7 +7101,7 @@
      *      //=> Nothing()
      */
     var composeK = function composeK() {
-        return arguments.length === 0 ? identity : compose.apply(this, map(chain, arguments));
+        return compose.apply(this, prepend(identity, map(chain, arguments)));
     };
 
     /**
@@ -6797,6 +7111,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.10.0
      * @category Function
      * @sig ((y -> Promise z), (x -> Promise y), ..., (a -> Promise b)) -> (a -> Promise z)
      * @param {...Function} functions
@@ -6820,6 +7135,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
      * @sig (* -> {*}) -> (* -> {*})
      * @param {Function} Fn The constructor function to wrap.
@@ -6827,7 +7143,7 @@
      * @example
      *
      *      // Constructor function
-     *      var Widget = function(config) {
+     *      var Widget = config => {
      *        // ...
      *      };
      *      Widget.prototype = {
@@ -6848,12 +7164,13 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig a -> [a] -> Boolean
      * @param {Object} a The item to compare against.
      * @param {Array} list The array to consider.
      * @return {Boolean} `true` if the item is in the list, `false` otherwise.
-     *
+     * @see R.any
      * @example
      *
      *      R.contains(3, [1, 2, 3]); //=> true
@@ -6867,6 +7184,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig [a] -> [a] -> [a]
      * @param {Array} list1 The first list.
@@ -6895,11 +7213,14 @@
      * Returns a new list without any consecutively repeating elements.
      * `R.equals` is used to determine equality.
      *
+     * Dispatches to the `dropRepeats` method of the first argument, if present.
+     *
      * Acts as a transducer if a transformer is given in list position.
      * @see R.transduce
      *
      * @func
      * @memberOf R
+     * @since v0.14.0
      * @category List
      * @sig [a] -> [a]
      * @param {Array} list The array to consider.
@@ -6915,6 +7236,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig [a] -> [a] -> [a]
      * @param {Array} list1 The first list.
@@ -6935,6 +7257,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.7.0
      * @see R.liftN
      * @category Function
      * @sig (*... -> *) -> ([*]... -> [*])
@@ -6942,14 +7265,12 @@
      * @return {Function} The function `fn` applicable to mappable objects.
      * @example
      *
-     *      var madd3 = R.lift(R.curry(function(a, b, c) {
-     *        return a + b + c;
-     *      }));
+     *      var madd3 = R.lift(R.curry((a, b, c) => a + b + c));
+     *
      *      madd3([1,2,3], [1,2,3], [1]); //=> [3, 4, 5, 4, 5, 6, 5, 6, 7]
      *
-     *      var madd5 = R.lift(R.curry(function(a, b, c, d, e) {
-     *        return a + b + c + d + e;
-     *      }));
+     *      var madd5 = R.lift(R.curry((a, b, c, d, e) => a + b + c + d + e));
+     *
      *      madd5([1,2], [3], [4, 5], [6], [7, 8]); //=> [21, 22, 22, 23, 22, 23, 23, 24]
      */
     var lift = _curry1(function lift(fn) {
@@ -6961,6 +7282,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Object
      * @sig [String] -> {String: *} -> {String: *}
      * @param {Array} names an array of String property names to omit from the new object
@@ -6989,6 +7311,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.16.0
      * @category Function
      * @see R.composeK
      * @sig Chain m => ((a -> m b), (b -> m c), ..., (y -> m z)) -> (m a -> m z)
@@ -7040,6 +7363,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.14.0
      * @category String
      * @sig * -> String
      * @param {*} val
@@ -7062,6 +7386,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Relation
      * @sig [a] -> [a] -> [a]
      * @param {Array} as The first list.
@@ -7083,6 +7408,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.16.0
      * @category List
      * @sig (a -> b) -> [a] -> [a]
      * @param {Function} fn A function used to produce a value to use during comparisons.
@@ -7107,6 +7433,84 @@
     });
 
     /**
+     * A function wrapping calls to the two functions in an `&&` operation, returning the result of the first
+     * function if it is false-y and the result of the second function otherwise.
+     *
+     * `R.both` will work on all other applicatives as well.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.12.0
+     * @category Logic
+     * @sig (*... -> Boolean) -> (*... -> Boolean) -> (*... -> Boolean)
+     * @param {Function} f a predicate
+     * @param {Function} g another predicate
+     * @return {Function} a function that applies its arguments to `f` and `g` and `&&`s their outputs together.
+     * @see R.and
+     * @example
+     *
+     *      var gt10 = x => x > 10;
+     *      var even = x => x % 2 === 0;
+     *      var f = R.both(gt10, even);
+     *      f(100); //=> true
+     *      f(101); //=> false
+     */
+    var both = lift(and);
+
+    /**
+     * Takes a function `f` and returns a function `g` such that:
+     *
+     *   - applying `g` to zero or more arguments will give __true__ if applying
+     *     the same arguments to `f` gives a logical __false__ value; and
+     *
+     *   - applying `g` to zero or more arguments will give __false__ if applying
+     *     the same arguments to `f` gives a logical __true__ value.
+     *
+     * `R.complement` will work on all other functors as well.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.12.0
+     * @category Logic
+     * @sig (*... -> *) -> (*... -> Boolean)
+     * @param {Function} f
+     * @return {Function}
+     * @see R.not
+     * @example
+     *
+     *      var isEven = n => n % 2 === 0;
+     *      var isOdd = R.complement(isEven);
+     *      isOdd(21); //=> true
+     *      isOdd(42); //=> false
+     */
+    var complement = lift(not);
+
+    /**
+     * A function wrapping calls to the two functions in an `||` operation, returning the result of the first
+     * function if it is truth-y and the result of the second function otherwise.
+     *
+     * `R.either` will work on all other applicatives as well.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.12.0
+     * @category Logic
+     * @sig (*... -> Boolean) -> (*... -> Boolean) -> (*... -> Boolean)
+     * @param {Function} f a predicate
+     * @param {Function} g another predicate
+     * @return {Function} a function that applies its arguments to `f` and `g` and `||`s their outputs together.
+     * @see R.or
+     * @example
+     *
+     *      var gt10 = x => x > 10;
+     *      var even = x => x % 2 === 0;
+     *      var f = R.either(gt10, even);
+     *      f(101); //=> true
+     *      f(8); //=> true
+     */
+    var either = lift(or);
+
+    /**
      * Turns a named method with a specified arity into a function
      * that can be called directly supplied with arguments and a target object.
      *
@@ -7115,6 +7519,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
      * @sig Number -> String -> (a -> b -> ... -> n -> Object -> *)
      * @param {Number} arity Number of arguments the returned function should take
@@ -7144,6 +7549,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category List
      * @sig String -> [a] -> String
      * @param {Number|String} separator The string used to separate the elements.
@@ -7166,6 +7572,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category Function
      * @sig (*... -> a) -> (*... -> a)
      * @param {Function} fn The function to memoize.
@@ -7173,7 +7580,7 @@
      * @example
      *
      *      var count = 0;
-     *      var factorial = R.memoize(function(n) {
+     *      var factorial = R.memoize(n => {
      *        count += 1;
      *        return R.product(R.range(1, n + 1));
      *      });
@@ -7199,9 +7606,10 @@
      *
      * @func
      * @memberOf R
+     * @since v0.1.0
      * @category String
-     * @sig String -> String -> [String]
-     * @param {String} sep The separator string.
+     * @sig (String | RegExp) -> String -> [String]
+     * @param {String|RegExp} sep The pattern.
      * @param {String} str The string to separate into an array.
      * @return {Array} The array of strings from `str` separated by `str`.
      * @see R.join
@@ -7215,10 +7623,35 @@
     var split = invoker(1, 'split');
 
     /**
+     * Determines whether a given string matches a given regular expression.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.12.0
+     * @see R.match
+     * @category String
+     * @sig RegExp -> String -> Boolean
+     * @param {RegExp} pattern
+     * @param {String} str
+     * @return {Boolean}
+     * @example
+     *
+     *      R.test(/^x/, 'xyz'); //=> true
+     *      R.test(/^y/, 'xyz'); //=> false
+     */
+    var test = _curry2(function test(pattern, str) {
+        if (!_isRegExp(pattern)) {
+            throw new TypeError('\u2018test\u2019 requires a value of type RegExp as its first argument; received ' + toString(pattern));
+        }
+        return _cloneRegExp(pattern).test(str);
+    });
+
+    /**
      * The lower case version of a string.
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category String
      * @sig String -> String
      * @param {String} str The string to lower case.
@@ -7235,6 +7668,7 @@
      *
      * @func
      * @memberOf R
+     * @since v0.9.0
      * @category String
      * @sig String -> String
      * @param {String} str The string to upper case.
@@ -7246,6 +7680,29 @@
      */
     var toUpper = invoker(0, 'toUpperCase');
 
+    /**
+     * Returns the result of concatenating the given lists or strings.
+     *
+     * Dispatches to the `concat` method of the second argument, if present.
+     *
+     * @func
+     * @memberOf R
+     * @since v0.1.0
+     * @category List
+     * @sig [a] -> [a] -> [a]
+     * @sig String -> String -> String
+     * @param {Array|String} a
+     * @param {Array|String} b
+     * @return {Array|String}
+     *
+     * @example
+     *
+     *      R.concat([], []); //=> []
+     *      R.concat([4, 5, 6], [1, 2, 3]); //=> [4, 5, 6, 1, 2, 3]
+     *      R.concat('ABC', 'DEF'); // 'ABCDEF'
+     */
+    var concat = flip(invoker(1, 'concat'));
+
     var R = {
         F: F,
         T: T,
@@ -7255,6 +7712,7 @@
         adjust: adjust,
         all: all,
         allPass: allPass,
+        allUniq: allUniq,
         always: always,
         and: and,
         any: any,
@@ -7304,6 +7762,7 @@
         dropWhile: dropWhile,
         either: either,
         empty: empty,
+        eqBy: eqBy,
         eqProps: eqProps,
         equals: equals,
         evolve: evolve,
@@ -7381,18 +7840,19 @@
         not: not,
         nth: nth,
         nthArg: nthArg,
-        nthChar: nthChar,
-        nthCharCode: nthCharCode,
+        objOf: objOf,
         of: of,
         omit: omit,
         once: once,
         or: or,
         over: over,
+        pair: pair,
         partial: partial,
         partialRight: partialRight,
         partition: partition,
         path: path,
         pathEq: pathEq,
+        pathOr: pathOr,
         pick: pick,
         pickAll: pickAll,
         pickBy: pickBy,
@@ -7452,12 +7912,14 @@
         uniq: uniq,
         uniqBy: uniqBy,
         uniqWith: uniqWith,
+        unless: unless,
         unnest: unnest,
         update: update,
         useWith: useWith,
         values: values,
         valuesIn: valuesIn,
         view: view,
+        when: when,
         where: where,
         whereEq: whereEq,
         wrap: wrap,

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,18 +7,20 @@
     <link rel="stylesheet" type="text/css" href="../style.css">
 </head>
 <body>
+    <input type="checkbox" id="open-nav">
     <header class="navbar navbar-fixed-top navbar-inverse container-fluid">
         <div class="navbar-header">
+            <label class="open-nav" for="open-nav"></label>
             <a class="navbar-brand" href="/">
                 <strong>Ramda</strong>
-                <span class="version">v0.17.1</span>
+                <span class="version">v0.18.0</span>
             </a>
         </div>
         <div class="navbar-left">
             <ul class="nav navbar-nav">
                 <li><a href="..">Home</a></li>
                 <li class="active"><a href="#">Documentation</a></li>
-                <li><a href="/repl?v=0.17.1">Try Ramda</a></li>
+                <li><a href="/repl?v=0.18.0">Try Ramda</a></li>
                 <li><a href="https://github.com/ramda/ramda">GitHub</a></li>
             </ul>
         </div>
@@ -78,6 +80,13 @@
                     allPass
                     <span data-category="Logic" class="label label-category pull-right"
                     >Logic</span>
+                </a>
+            </li>
+            <li class="func" data-name="allUniq" data-category="List">
+                <a href="#allUniq">
+                    allUniq
+                    <span data-category="List" class="label label-category pull-right"
+                    >List</span>
                 </a>
             </li>
             <li class="func" data-name="always" data-category="Function">
@@ -421,6 +430,13 @@
                     empty
                     <span data-category="Function" class="label label-category pull-right"
                     >Function</span>
+                </a>
+            </li>
+            <li class="func" data-name="eqBy" data-category="Relation">
+                <a href="#eqBy">
+                    eqBy
+                    <span data-category="Relation" class="label label-category pull-right"
+                    >Relation</span>
                 </a>
             </li>
             <li class="func" data-name="eqProps" data-category="Object">
@@ -969,18 +985,11 @@
                     >Function</span>
                 </a>
             </li>
-            <li class="func" data-name="nthChar" data-category="String">
-                <a href="#nthChar">
-                    nthChar
-                    <span data-category="String" class="label label-category pull-right"
-                    >String</span>
-                </a>
-            </li>
-            <li class="func" data-name="nthCharCode" data-category="String">
-                <a href="#nthCharCode">
-                    nthCharCode
-                    <span data-category="String" class="label label-category pull-right"
-                    >String</span>
+            <li class="func" data-name="objOf" data-category="Object">
+                <a href="#objOf">
+                    objOf
+                    <span data-category="Object" class="label label-category pull-right"
+                    >Object</span>
                 </a>
             </li>
             <li class="func" data-name="of" data-category="Function">
@@ -1018,6 +1027,13 @@
                     >Object</span>
                 </a>
             </li>
+            <li class="func" data-name="pair" data-category="List">
+                <a href="#pair">
+                    pair
+                    <span data-category="List" class="label label-category pull-right"
+                    >List</span>
+                </a>
+            </li>
             <li class="func" data-name="partial" data-category="Function">
                 <a href="#partial">
                     partial
@@ -1051,6 +1067,13 @@
                     pathEq
                     <span data-category="Relation" class="label label-category pull-right"
                     >Relation</span>
+                </a>
+            </li>
+            <li class="func" data-name="pathOr" data-category="Object">
+                <a href="#pathOr">
+                    pathOr
+                    <span data-category="Object" class="label label-category pull-right"
+                    >Object</span>
                 </a>
             </li>
             <li class="func" data-name="pick" data-category="Object">
@@ -1473,6 +1496,13 @@
                     >List</span>
                 </a>
             </li>
+            <li class="func" data-name="unless" data-category="Logic">
+                <a href="#unless">
+                    unless
+                    <span data-category="Logic" class="label label-category pull-right"
+                    >Logic</span>
+                </a>
+            </li>
             <li class="func" data-name="unnest" data-category="List">
                 <a href="#unnest">
                     unnest
@@ -1513,6 +1543,13 @@
                     view
                     <span data-category="Object" class="label label-category pull-right"
                     >Object</span>
+                </a>
+            </li>
+            <li class="func" data-name="when" data-category="Logic">
+                <a href="#when">
+                    when
+                    <span data-category="Logic" class="label label-category pull-right"
+                    >Logic</span>
                 </a>
             </li>
             <li class="func" data-name="where" data-category="Object">
@@ -1572,7 +1609,7 @@
                 <a tabindex="2" class="name" href="#__">__</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/__.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/__.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -1614,7 +1651,7 @@ greet(<span class="hljs-string">'Alice'</span>); <span class="hljs-comment">//=&
                 <a tabindex="2" class="name" href="#add">add</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/add.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/add.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -1663,7 +1700,7 @@ R.add(<span class="hljs-number">7</span>)(<span class="hljs-number">10</span>); 
                 <a tabindex="2" class="name" href="#addIndex">addIndex</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/addIndex.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/addIndex.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -1703,7 +1740,7 @@ parameter.  (This latter might be unimportant if the list parameter is not used.
 
 
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> mapIndexed = R.addIndex(R.map);
-mapIndexed(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">val, idx</span>) </span>{<span class="hljs-keyword">return</span> idx + <span class="hljs-string">'-'</span> + val;}, [<span class="hljs-string">'f'</span>, <span class="hljs-string">'o'</span>, <span class="hljs-string">'o'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>, <span class="hljs-string">'r'</span>]);
+mapIndexed((val, idx) =&gt; idx + <span class="hljs-string">'-'</span> + val, [<span class="hljs-string">'f'</span>, <span class="hljs-string">'o'</span>, <span class="hljs-string">'o'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>, <span class="hljs-string">'r'</span>]);
 <span class="hljs-comment">//=&gt; ['0-f', '1-o', '2-o', '3-b', '4-a', '5-r']</span></code></pre>
         </section>
         <section class="card" id="adjust">
@@ -1711,7 +1748,7 @@ mapIndexed(<span class="hljs-function"><span class="hljs-keyword">function</span
                 <a tabindex="2" class="name" href="#adjust">adjust</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/adjust.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/adjust.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -1774,7 +1811,7 @@ R.adjust(R.add(<span class="hljs-number">10</span>))(<span class="hljs-number">1
                 <a tabindex="2" class="name" href="#all">all</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/all.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/all.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -1812,6 +1849,7 @@ R.adjust(R.add(<span class="hljs-number">10</span>))(<span class="hljs-number">1
 
             <div class="description"><p>Returns <code>true</code> if all elements of the list match the predicate, <code>false</code> if there are any
 that don&#39;t.</p>
+<p>Dispatches to the <code>all</code> method of the second argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
@@ -1833,7 +1871,7 @@ R.all(lessThan3)([<span class="hljs-number">1</span>, <span class="hljs-number">
                 <a tabindex="2" class="name" href="#allPass">allPass</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/allPass.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/allPass.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -1849,27 +1887,22 @@ R.all(lessThan3)([<span class="hljs-number">1</span>, <span class="hljs-number">
                 <ul class="list-group">
                     <li class="list-group-item">
                         <span class="type">Array</span>
-                        <span class="name">list</span>
-                        <span class="description"><p>An array of predicate functions</p>
-</span>
-                    </li>
-                    <li class="list-group-item">
-                        <span class="type">*</span>
-                        <span class="name">optional</span>
-                        <span class="description"><p>Any arguments to pass into the predicates</p>
-</span>
+                        <span class="name">preds</span>
+                        <span class="description"></span>
                     </li>
                 </ul>
                 <div class="panel-body">
                     <span class="returns">Returns</span>
                     <span class="type">function</span>
-                    <span class="description"><p>a function that applies its arguments to each of
-        the predicates, returning <code>true</code> if all are satisfied.</p>
-</span>
+                    <span class="description"></span>
                 </div>
             </div>
 
-            <div class="description"><p>Given a list of predicates, returns a new predicate that will be true exactly when all of them are.</p>
+            <div class="description"><p>Takes a list of predicates and returns a predicate that returns true
+for a given list of arguments if every one of the provided predicates
+is satisfied by those arguments.</p>
+<p>The function returned is a curried function whose arity matches that of
+the highest-arity predicate.</p>
 </div>
 
 
@@ -1878,18 +1911,63 @@ R.all(lessThan3)([<span class="hljs-number">1</span>, <span class="hljs-number">
                 <a href="#anyPass">anyPass</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> gt10 = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{ <span class="hljs-keyword">return</span> x &gt; <span class="hljs-number">10</span>; };
-<span class="hljs-keyword">var</span> even = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{ <span class="hljs-keyword">return</span> x % <span class="hljs-number">2</span> === <span class="hljs-number">0</span>};
-<span class="hljs-keyword">var</span> f = R.allPass([gt10, even]);
-f(<span class="hljs-number">11</span>); <span class="hljs-comment">//=&gt; false</span>
-f(<span class="hljs-number">12</span>); <span class="hljs-comment">//=&gt; true</span></code></pre>
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isQueen = R.propEq(<span class="hljs-string">'rank'</span>, <span class="hljs-string">'Q'</span>);
+<span class="hljs-keyword">var</span> isSpade = R.propEq(<span class="hljs-string">'suit'</span>, <span class="hljs-string">'♠︎'</span>);
+<span class="hljs-keyword">var</span> isQueenOfSpades = R.allPass([isQueen, isSpade]);
+
+isQueenOfSpades({rank: <span class="hljs-string">'Q'</span>, suit: <span class="hljs-string">'♣︎'</span>}); <span class="hljs-comment">//=&gt; false</span>
+isQueenOfSpades({rank: <span class="hljs-string">'Q'</span>, suit: <span class="hljs-string">'♠︎'</span>}); <span class="hljs-comment">//=&gt; true</span></code></pre>
+        </section>
+        <section class="card" id="allUniq">
+            <h2>
+                <a tabindex="2" class="name" href="#allUniq">allUniq</a>
+                <span class="pull-right">
+                        <span class="label label-category">List</span>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/allUniq.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                </span>
+            </h2>
+
+
+            <div>
+                <button class="sig btn btn-link" data-collapser="#__details-allUniq">
+                    <span class="caret rotated"></span>
+                    [a] → Boolean
+                </button>
+            </div>
+
+            <div class="details collapse panel panel-default" id="__details-allUniq">
+                <ul class="list-group">
+                    <li class="list-group-item">
+                        <span class="type">Array</span>
+                        <span class="name">list</span>
+                        <span class="description"><p>The array to consider.</p>
+</span>
+                    </li>
+                </ul>
+                <div class="panel-body">
+                    <span class="returns">Returns</span>
+                    <span class="type">Boolean</span>
+                    <span class="description"><p><code>true</code> if all elements are unique, else <code>false</code>.</p>
+</span>
+                </div>
+            </div>
+
+            <div class="description"><p>Returns <code>true</code> if all elements are unique, in <code>R.equals</code> terms,
+otherwise <code>false</code>.</p>
+</div>
+
+
+
+            <pre><code class="hljs javascript">R.allUniq([<span class="hljs-string">'1'</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">//=&gt; true</span>
+R.allUniq([<span class="hljs-number">1</span>, <span class="hljs-number">1</span>]);   <span class="hljs-comment">//=&gt; false</span>
+R.allUniq([[<span class="hljs-number">42</span>], [<span class="hljs-number">42</span>]]); <span class="hljs-comment">//=&gt; false</span></code></pre>
         </section>
         <section class="card" id="always">
             <h2>
                 <a tabindex="2" class="name" href="#always">always</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/always.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/always.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -1934,7 +2012,7 @@ t(); <span class="hljs-comment">//=&gt; 'Tee'</span></code></pre>
                 <a tabindex="2" class="name" href="#and">and</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/and.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/and.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -1949,30 +2027,27 @@ t(); <span class="hljs-comment">//=&gt; 'Tee'</span></code></pre>
             <div class="details collapse panel panel-default" id="__details-and">
                 <ul class="list-group">
                     <li class="list-group-item">
-                        <span class="type">*</span>
+                        <span class="type">Boolean</span>
                         <span class="name">a</span>
-                        <span class="description"><p>any value</p>
+                        <span class="description"><p>A boolean value</p>
 </span>
                     </li>
                     <li class="list-group-item">
-                        <span class="type">*</span>
+                        <span class="type">Boolean</span>
                         <span class="name">b</span>
-                        <span class="description"><p>any other value</p>
+                        <span class="description"><p>A boolean value</p>
 </span>
                     </li>
                 </ul>
                 <div class="panel-body">
                     <span class="returns">Returns</span>
-                    <span class="type">*</span>
-                    <span class="description"><p>the first argument if falsy otherwise the second argument.</p>
+                    <span class="type">Boolean</span>
+                    <span class="description"><p><code>true</code> if both arguments are <code>true</code>, <code>false</code> otherwise</p>
 </span>
                 </div>
             </div>
 
-            <div class="description"><p>A function that returns the first argument if it&#39;s falsy otherwise the second
-argument. Note that this is NOT short-circuited, meaning that if expressions
-are passed they are both evaluated.</p>
-<p>Dispatches to the <code>and</code> method of the first argument if applicable.</p>
+            <div class="description"><p>Returns <code>true</code> if both arguments are <code>true</code>; <code>false</code> otherwise.</p>
 </div>
 
 
@@ -1981,16 +2056,17 @@ are passed they are both evaluated.</p>
                 <a href="#both">both</a>.
             </div>
 
-            <pre><code class="hljs javascript">R.and(<span class="hljs-literal">false</span>, <span class="hljs-literal">true</span>); <span class="hljs-comment">//=&gt; false</span>
-R.and(<span class="hljs-number">0</span>, []); <span class="hljs-comment">//=&gt; 0</span>
-R.and(<span class="hljs-literal">null</span>, <span class="hljs-string">''</span>); =&gt; <span class="hljs-literal">null</span></code></pre>
+            <pre><code class="hljs javascript">R.and(<span class="hljs-literal">true</span>, <span class="hljs-literal">true</span>); <span class="hljs-comment">//=&gt; true</span>
+R.and(<span class="hljs-literal">true</span>, <span class="hljs-literal">false</span>); <span class="hljs-comment">//=&gt; false</span>
+R.and(<span class="hljs-literal">false</span>, <span class="hljs-literal">true</span>); <span class="hljs-comment">//=&gt; false</span>
+R.and(<span class="hljs-literal">false</span>, <span class="hljs-literal">false</span>); <span class="hljs-comment">//=&gt; false</span></code></pre>
         </section>
         <section class="card" id="any">
             <h2>
                 <a tabindex="2" class="name" href="#any">any</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/any.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/any.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2028,6 +2104,7 @@ R.and(<span class="hljs-literal">null</span>, <span class="hljs-string">''</span
 
             <div class="description"><p>Returns <code>true</code> if at least one of elements of the list match the predicate, <code>false</code>
 otherwise.</p>
+<p>Dispatches to the <code>any</code> method of the second argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
@@ -2049,7 +2126,7 @@ R.any(lessThan2)([<span class="hljs-number">1</span>, <span class="hljs-number">
                 <a tabindex="2" class="name" href="#anyPass">anyPass</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/anyPass.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/anyPass.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2065,27 +2142,22 @@ R.any(lessThan2)([<span class="hljs-number">1</span>, <span class="hljs-number">
                 <ul class="list-group">
                     <li class="list-group-item">
                         <span class="type">Array</span>
-                        <span class="name">list</span>
-                        <span class="description"><p>An array of predicate functions</p>
-</span>
-                    </li>
-                    <li class="list-group-item">
-                        <span class="type">*</span>
-                        <span class="name">optional</span>
-                        <span class="description"><p>Any arguments to pass into the predicates</p>
-</span>
+                        <span class="name">preds</span>
+                        <span class="description"></span>
                     </li>
                 </ul>
                 <div class="panel-body">
                     <span class="returns">Returns</span>
                     <span class="type">function</span>
-                    <span class="description"><p>A function that applies its arguments to each of the predicates, returning
-        <code>true</code> if all are satisfied.</p>
-</span>
+                    <span class="description"></span>
                 </div>
             </div>
 
-            <div class="description"><p>Given a list of predicates returns a new predicate that will be true exactly when any one of them is.</p>
+            <div class="description"><p>Takes a list of predicates and returns a predicate that returns true for
+a given list of arguments if at least one of the provided predicates is
+satisfied by those arguments.</p>
+<p>The function returned is a curried function whose arity matches that of
+the highest-arity predicate.</p>
 </div>
 
 
@@ -2094,19 +2166,18 @@ R.any(lessThan2)([<span class="hljs-number">1</span>, <span class="hljs-number">
                 <a href="#allPass">allPass</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> gt10 = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{ <span class="hljs-keyword">return</span> x &gt; <span class="hljs-number">10</span>; };
-<span class="hljs-keyword">var</span> even = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{ <span class="hljs-keyword">return</span> x % <span class="hljs-number">2</span> === <span class="hljs-number">0</span>};
-<span class="hljs-keyword">var</span> f = R.anyPass([gt10, even]);
-f(<span class="hljs-number">11</span>); <span class="hljs-comment">//=&gt; true</span>
-f(<span class="hljs-number">8</span>); <span class="hljs-comment">//=&gt; true</span>
-f(<span class="hljs-number">9</span>); <span class="hljs-comment">//=&gt; false</span></code></pre>
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> gte = R.anyPass([R.gt, R.equals]);
+
+gte(<span class="hljs-number">3</span>, <span class="hljs-number">2</span>); <span class="hljs-comment">//=&gt; true</span>
+gte(<span class="hljs-number">2</span>, <span class="hljs-number">2</span>); <span class="hljs-comment">//=&gt; true</span>
+gte(<span class="hljs-number">2</span>, <span class="hljs-number">3</span>); <span class="hljs-comment">//=&gt; false</span></code></pre>
         </section>
         <section class="card" id="ap">
             <h2>
                 <a tabindex="2" class="name" href="#ap">ap</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/ap.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/ap.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2142,6 +2213,8 @@ f(<span class="hljs-number">9</span>); <span class="hljs-comment">//=&gt; false<
             </div>
 
             <div class="description"><p>ap applies a list of functions to a list of values.</p>
+<p>Dispatches to the <code>ap</code> method of the second argument, if present. Also treats
+functions as applicatives.</p>
 </div>
 
 
@@ -2153,7 +2226,7 @@ f(<span class="hljs-number">9</span>); <span class="hljs-comment">//=&gt; false<
                 <a tabindex="2" class="name" href="#aperture">aperture</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/aperture.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/aperture.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2190,9 +2263,15 @@ f(<span class="hljs-number">9</span>); <span class="hljs-comment">//=&gt; false<
 
             <div class="description"><p>Returns a new list, composed of n-tuples of consecutive elements
 If <code>n</code> is greater than the length of the list, an empty list is returned.</p>
+<p>Dispatches to the <code>aperture</code> method of the second argument, if present.</p>
+<p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
 
+            <div class="see">
+                See also
+                <a href="#transduce">transduce</a>.
+            </div>
 
             <pre><code class="hljs javascript">R.aperture(<span class="hljs-number">2</span>, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>]); <span class="hljs-comment">//=&gt; [[1, 2], [2, 3], [3, 4], [4, 5]]</span>
 R.aperture(<span class="hljs-number">3</span>, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>]); <span class="hljs-comment">//=&gt; [[1, 2, 3], [2, 3, 4], [3, 4, 5]]</span>
@@ -2203,7 +2282,7 @@ R.aperture(<span class="hljs-number">7</span>, [<span class="hljs-number">1</spa
                 <a tabindex="2" class="name" href="#append">append</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/append.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/append.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2258,7 +2337,7 @@ R.append([<span class="hljs-string">'tests'</span>], [<span class="hljs-string">
                 <a tabindex="2" class="name" href="#apply">apply</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/apply.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/apply.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2310,7 +2389,7 @@ R.apply(<span class="hljs-built_in">Math</span>.max, nums); <span class="hljs-co
                 <a tabindex="2" class="name" href="#assoc">assoc</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/assoc.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/assoc.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2370,7 +2449,7 @@ properties are copied by reference.</p>
                 <a tabindex="2" class="name" href="#assocPath">assocPath</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/assocPath.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/assocPath.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2431,7 +2510,7 @@ are copied by reference.</p>
                 <a tabindex="2" class="name" href="#binary">binary</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/binary.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/binary.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2466,6 +2545,7 @@ parameters. Any extraneous parameters will not be passed to the supplied functio
 </div>
 
 
+
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> takesThreeArgs = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b, c</span>) </span>{
   <span class="hljs-keyword">return</span> [a, b, c];
 };
@@ -2482,7 +2562,7 @@ takesTwoArgs(<span class="hljs-number">1</span>, <span class="hljs-number">2</sp
                 <a tabindex="2" class="name" href="#bind">bind</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/bind.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/bind.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2534,7 +2614,7 @@ Note: <code>R.bind</code> does not provide the additional argument-binding capab
                 <a tabindex="2" class="name" href="#both">both</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/both.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/both.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2570,9 +2650,8 @@ Note: <code>R.bind</code> does not provide the additional argument-binding capab
             </div>
 
             <div class="description"><p>A function wrapping calls to the two functions in an <code>&amp;&amp;</code> operation, returning the result of the first
-function if it is false-y and the result of the second function otherwise.  Note that this is
-short-circuited, meaning that the second function will not be invoked if the first returns a false-y
-value.</p>
+function if it is false-y and the result of the second function otherwise.</p>
+<p><code>R.both</code> will work on all other applicatives as well.</p>
 </div>
 
 
@@ -2581,8 +2660,8 @@ value.</p>
                 <a href="#and">and</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> gt10 = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{ <span class="hljs-keyword">return</span> x &gt; <span class="hljs-number">10</span>; };
-<span class="hljs-keyword">var</span> even = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{ <span class="hljs-keyword">return</span> x % <span class="hljs-number">2</span> === <span class="hljs-number">0</span> };
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> gt10 = x =&gt; x &gt; <span class="hljs-number">10</span>;
+<span class="hljs-keyword">var</span> even = x =&gt; x % <span class="hljs-number">2</span> === <span class="hljs-number">0</span>;
 <span class="hljs-keyword">var</span> f = R.both(gt10, even);
 f(<span class="hljs-number">100</span>); <span class="hljs-comment">//=&gt; true</span>
 f(<span class="hljs-number">101</span>); <span class="hljs-comment">//=&gt; false</span></code></pre>
@@ -2592,7 +2671,7 @@ f(<span class="hljs-number">101</span>); <span class="hljs-comment">//=&gt; fals
                 <a tabindex="2" class="name" href="#call">call</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/call.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/call.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2653,7 +2732,7 @@ format({indent: <span class="hljs-number">2</span>, value: <span class="hljs-str
                 <a tabindex="2" class="name" href="#chain">chain</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/chain.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/chain.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2686,15 +2765,13 @@ format({indent: <span class="hljs-number">2</span>, value: <span class="hljs-str
             </div>
 
             <div class="description"><p><code>chain</code> maps a function over a list and concatenates the results.
-This implementation is compatible with the
-Fantasy-land Chain spec, and will work with types that implement that spec.
 <code>chain</code> is also known as <code>flatMap</code> in some libraries</p>
+<p>Dispatches to the <code>chain</code> method of the second argument, if present.</p>
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> duplicate = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">n</span>) </span>{
-  <span class="hljs-keyword">return</span> [n, n];
-};
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> duplicate = n =&gt; [n, n];
 R.chain(duplicate, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">//=&gt; [1, 1, 2, 2, 3, 3]</span></code></pre>
         </section>
         <section class="card" id="clone">
@@ -2702,7 +2779,7 @@ R.chain(duplicate, [<span class="hljs-number">1</span>, <span class="hljs-number
                 <a tabindex="2" class="name" href="#clone">clone</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/clone.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/clone.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2731,9 +2808,9 @@ R.chain(duplicate, [<span class="hljs-number">1</span>, <span class="hljs-number
                 </div>
             </div>
 
-            <div class="description"><p>Creates a deep copy of the value which may contain (nested) <code>Array</code>s and
-<code>Object</code>s, <code>Number</code>s, <code>String</code>s, <code>Boolean</code>s and <code>Date</code>s. <code>Function</code>s are
-not copied, but assigned by their reference.</p>
+            <div class="description"><p>Creates a deep copy of the value which may contain (nested) <code>Array</code>s and <code>Object</code>s, <code>Number</code>s,
+<code>String</code>s, <code>Boolean</code>s and <code>Date</code>s. <code>Function</code>s are not copied, but assigned by their
+reference. Dispatches to a <code>clone</code> method if present.</p>
 </div>
 
 
@@ -2747,7 +2824,7 @@ objects[<span class="hljs-number">0</span>] === objectsClone[<span class="hljs-n
                 <a tabindex="2" class="name" href="#commute">commute</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/commute.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/commute.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2801,7 +2878,7 @@ R.commute(Maybe.of, [Just(<span class="hljs-number">1</span>), Just(<span class=
                 <a tabindex="2" class="name" href="#commuteMap">commuteMap</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/commuteMap.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/commuteMap.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2809,7 +2886,7 @@ R.commute(Maybe.of, [Just(<span class="hljs-number">1</span>), Just(<span class=
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-commuteMap">
                     <span class="caret rotated"></span>
-                    Functor f =&gt; (f a → f b) → (x → f x) → [f a] → f [b]
+                    Functor f =&gt; (a → f b) → (x → f x) → [a] → f [b]
                 </button>
             </div>
 
@@ -2851,18 +2928,25 @@ a mapping function to the elements of the list along the way.</p>
                 <a href="#commute">commute</a>.
             </div>
 
-            <pre><code class="hljs javascript">R.commuteMap(R.map(R.add(<span class="hljs-number">10</span>)), R.of, [[<span class="hljs-number">1</span>], [<span class="hljs-number">2</span>, <span class="hljs-number">3</span>]]);   <span class="hljs-comment">//=&gt; [[11, 12], [11, 13]]</span>
-R.commuteMap(R.map(R.add(<span class="hljs-number">10</span>)), R.of, [[<span class="hljs-number">1</span>, <span class="hljs-number">2</span>], [<span class="hljs-number">3</span>]]);   <span class="hljs-comment">//=&gt; [[11, 13], [12, 13]]</span>
-R.commuteMap(R.map(R.add(<span class="hljs-number">10</span>)), R.of, [[<span class="hljs-number">1</span>], [<span class="hljs-number">2</span>], [<span class="hljs-number">3</span>]]); <span class="hljs-comment">//=&gt; [[11, 12, 13]]</span>
-R.commuteMap(R.map(R.add(<span class="hljs-number">10</span>)), Maybe.of, [Just(<span class="hljs-number">1</span>), Just(<span class="hljs-number">2</span>), Just(<span class="hljs-number">3</span>)]);   <span class="hljs-comment">//=&gt; Just([11, 12, 13])</span>
-R.commuteMap(R.map(R.add(<span class="hljs-number">10</span>)), Maybe.of, [Just(<span class="hljs-number">1</span>), Just(<span class="hljs-number">2</span>), Nothing()]); <span class="hljs-comment">//=&gt; Nothing()</span></code></pre>
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> add10 = R.map(R.add(<span class="hljs-number">10</span>));
+R.commuteMap(add10, R.of, [[<span class="hljs-number">1</span>], [<span class="hljs-number">2</span>, <span class="hljs-number">3</span>]]);   <span class="hljs-comment">//=&gt; [[11, 12], [11, 13]]</span>
+R.commuteMap(add10, R.of, [[<span class="hljs-number">1</span>, <span class="hljs-number">2</span>], [<span class="hljs-number">3</span>]]);   <span class="hljs-comment">//=&gt; [[11, 13], [12, 13]]</span>
+R.commuteMap(add10, R.of, [[<span class="hljs-number">1</span>], [<span class="hljs-number">2</span>], [<span class="hljs-number">3</span>]]); <span class="hljs-comment">//=&gt; [[11, 12, 13]]</span>
+R.commuteMap(add10, Maybe.of, [Just(<span class="hljs-number">1</span>), Just(<span class="hljs-number">2</span>), Just(<span class="hljs-number">3</span>)]);   <span class="hljs-comment">//=&gt; Just([11, 12, 13])</span>
+R.commuteMap(add10, Maybe.of, [Just(<span class="hljs-number">1</span>), Just(<span class="hljs-number">2</span>), Nothing()]); <span class="hljs-comment">//=&gt; Nothing()</span>
+
+<span class="hljs-keyword">var</span> fetch = url =&gt; Future((rej, res) =&gt; http.get(url, res).on(<span class="hljs-string">'error'</span>, rej));
+R.commuteMap(fetch, Future.of, [
+  <span class="hljs-string">'http://ramdajs.com'</span>,
+  <span class="hljs-string">'http://github.com/ramda'</span>
+]); <span class="hljs-comment">//=&gt; Future([IncomingMessage, IncomingMessage])</span></code></pre>
         </section>
         <section class="card" id="comparator">
             <h2>
                 <a tabindex="2" class="name" href="#comparator">comparator</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/comparator.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/comparator.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2895,9 +2979,8 @@ R.commuteMap(R.map(R.add(<span class="hljs-number">10</span>)), Maybe.of, [Just(
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> cmp = R.comparator(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{
-  <span class="hljs-keyword">return</span> a.age &lt; b.age;
-});
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> cmp = R.comparator((a, b) =&gt; a.age &lt; b.age);
 <span class="hljs-keyword">var</span> people = [
   <span class="hljs-comment">// ...</span>
 ];
@@ -2908,7 +2991,7 @@ R.sort(cmp, people);</code></pre>
                 <a tabindex="2" class="name" href="#complement">complement</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/complement.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/complement.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2944,6 +3027,7 @@ the same arguments to <code>f</code> gives a logical <strong>false</strong> valu
 the same arguments to <code>f</code> gives a logical <strong>true</strong> value.</p>
 </li>
 </ul>
+<p><code>R.complement</code> will work on all other functors as well.</p>
 </div>
 
 
@@ -2952,7 +3036,7 @@ the same arguments to <code>f</code> gives a logical <strong>true</strong> value
                 <a href="#not">not</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isEven = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">n</span>) </span>{ <span class="hljs-keyword">return</span> n % <span class="hljs-number">2</span> === <span class="hljs-number">0</span>; };
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isEven = n =&gt; n % <span class="hljs-number">2</span> === <span class="hljs-number">0</span>;
 <span class="hljs-keyword">var</span> isOdd = R.complement(isEven);
 isOdd(<span class="hljs-number">21</span>); <span class="hljs-comment">//=&gt; true</span>
 isOdd(<span class="hljs-number">42</span>); <span class="hljs-comment">//=&gt; false</span></code></pre>
@@ -2962,7 +3046,7 @@ isOdd(<span class="hljs-number">42</span>); <span class="hljs-comment">//=&gt; f
                 <a tabindex="2" class="name" href="#compose">compose</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/compose.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/compose.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -2970,7 +3054,7 @@ isOdd(<span class="hljs-number">42</span>); <span class="hljs-comment">//=&gt; f
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-compose">
                     <span class="caret rotated"></span>
-                    ((y → z), (x → y), …, (o → p), ((a, b, …, n) → o)) → (a → b → … → n → z)
+                    ((y → z), (x → y), …, (o → p), ((a, b, …, n) → o)) → ((a, b, …, n) → z)
                 </button>
             </div>
 
@@ -3008,7 +3092,7 @@ f(<span class="hljs-number">3</span>, <span class="hljs-number">4</span>); <span
                 <a tabindex="2" class="name" href="#composeK">composeK</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/composeK.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/composeK.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3068,7 +3152,7 @@ getStateCode(Maybe.of(<span class="hljs-string">'[Invalid JSON]'</span>));
                 <a tabindex="2" class="name" href="#composeP">composeP</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/composeP.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/composeP.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3114,7 +3198,7 @@ functions must be unary.</p>
                 <a tabindex="2" class="name" href="#concat">concat</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/concat.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/concat.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3130,30 +3214,24 @@ functions must be unary.</p>
                 <ul class="list-group">
                     <li class="list-group-item">
                         <span class="type">Array</span>
-                        <span class="name">list1</span>
-                        <span class="description"><p>The first list to merge.</p>
-</span>
+                        <span class="name">a</span>
+                        <span class="description"></span>
                     </li>
                     <li class="list-group-item">
                         <span class="type">Array</span>
-                        <span class="name">list2</span>
-                        <span class="description"><p>The second set to merge.</p>
-</span>
+                        <span class="name">b</span>
+                        <span class="description"></span>
                     </li>
                 </ul>
                 <div class="panel-body">
                     <span class="returns">Returns</span>
                     <span class="type">Array</span>
-                    <span class="description"><p>A new array consisting of the contents of <code>list1</code> followed by the
-        contents of <code>list2</code>. If, instead of an Array for <code>list1</code>, you pass an
-        object with a <code>concat</code> method on it, <code>concat</code> will call <code>list1.concat</code>
-        and pass it the value of <code>list2</code>.</p>
-</span>
+                    <span class="description"></span>
                 </div>
             </div>
 
-            <div class="description"><p>Returns a new list consisting of the elements of the first list followed by the elements
-of the second.</p>
+            <div class="description"><p>Returns the result of concatenating the given lists or strings.</p>
+<p>Dispatches to the <code>concat</code> method of the second argument, if present.</p>
 </div>
 
 
@@ -3167,7 +3245,7 @@ R.concat(<span class="hljs-string">'ABC'</span>, <span class="hljs-string">'DEF'
                 <a tabindex="2" class="name" href="#cond">cond</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/cond.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/cond.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3207,7 +3285,7 @@ If none of the predicates matches, <code>fn</code> returns undefined.</p>
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> fn = R.cond([
   [R.equals(<span class="hljs-number">0</span>),   R.always(<span class="hljs-string">'water freezes at 0°C'</span>)],
   [R.equals(<span class="hljs-number">100</span>), R.always(<span class="hljs-string">'water boils at 100°C'</span>)],
-  [R.T,           <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">temp</span>) </span>{ <span class="hljs-keyword">return</span> <span class="hljs-string">'nothing special happens at '</span> + temp + <span class="hljs-string">'°C'</span>; }]
+  [R.T,           temp =&gt; <span class="hljs-string">'nothing special happens at '</span> + temp + <span class="hljs-string">'°C'</span>]
 ]);
 fn(<span class="hljs-number">0</span>); <span class="hljs-comment">//=&gt; 'water freezes at 0°C'</span>
 fn(<span class="hljs-number">50</span>); <span class="hljs-comment">//=&gt; 'nothing special happens at 50°C'</span>
@@ -3218,7 +3296,7 @@ fn(<span class="hljs-number">100</span>); <span class="hljs-comment">//=&gt; 'wa
                 <a tabindex="2" class="name" href="#construct">construct</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/construct.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/construct.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3254,7 +3332,7 @@ arguments and returns the same type.</p>
 
 
             <pre><code class="hljs javascript"><span class="hljs-comment">// Constructor function</span>
-<span class="hljs-keyword">var</span> Widget = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
+<span class="hljs-keyword">var</span> Widget = config =&gt; {
   <span class="hljs-comment">// ...</span>
 };
 Widget.prototype = {
@@ -3270,7 +3348,7 @@ R.map(R.construct(Widget), allConfigs); <span class="hljs-comment">// a list of 
                 <a tabindex="2" class="name" href="#constructN">constructN</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/constructN.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/constructN.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3313,7 +3391,7 @@ to allow using variadic constructor functions.</p>
 
 
             <pre><code class="hljs javascript"><span class="hljs-comment">// Variadic constructor function</span>
-<span class="hljs-keyword">var</span> Widget = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+<span class="hljs-keyword">var</span> Widget = () =&gt; {
   <span class="hljs-keyword">this</span>.children = <span class="hljs-built_in">Array</span>.prototype.slice.call(<span class="hljs-built_in">arguments</span>);
   <span class="hljs-comment">// ...</span>
 };
@@ -3330,7 +3408,7 @@ R.map(R.constructN(<span class="hljs-number">1</span>, Widget), allConfigs); <sp
                 <a tabindex="2" class="name" href="#contains">contains</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/contains.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/contains.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3370,6 +3448,10 @@ to at least one element of the given list; <code>false</code> otherwise.</p>
 </div>
 
 
+            <div class="see">
+                See also
+                <a href="#any">any</a>.
+            </div>
 
             <pre><code class="hljs javascript">R.contains(<span class="hljs-number">3</span>, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">//=&gt; true</span>
 R.contains(<span class="hljs-number">4</span>, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">//=&gt; false</span>
@@ -3380,10 +3462,13 @@ R.contains([<span class="hljs-number">42</span>], [[<span class="hljs-number">42
                 <a tabindex="2" class="name" href="#containsWith">containsWith</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/containsWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/containsWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
+            <div class="deprecated">
+                Deprecated since v0.18.0
+            </div>
 
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-containsWith">
@@ -3427,16 +3512,18 @@ equality predicate for <code>x</code>.</p>
 
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> xs = [{x: <span class="hljs-number">12</span>}, {x: <span class="hljs-number">11</span>}, {x: <span class="hljs-number">10</span>}];
-R.containsWith(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{ <span class="hljs-keyword">return</span> a.x === b.x; }, {x: <span class="hljs-number">10</span>}, xs); <span class="hljs-comment">//=&gt; true</span>
-R.containsWith(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{ <span class="hljs-keyword">return</span> a.x === b.x; }, {x: <span class="hljs-number">1</span>}, xs); <span class="hljs-comment">//=&gt; false</span></code></pre>
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> absEq = (a, b) =&gt; <span class="hljs-built_in">Math</span>.abs(a) === <span class="hljs-built_in">Math</span>.abs(b);
+R.containsWith(absEq, <span class="hljs-number">5</span>, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">//=&gt; false</span>
+R.containsWith(absEq, <span class="hljs-number">5</span>, [<span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>]); <span class="hljs-comment">//=&gt; true</span>
+R.containsWith(absEq, <span class="hljs-number">5</span>, [-<span class="hljs-number">1</span>, -<span class="hljs-number">2</span>, -<span class="hljs-number">3</span>]); <span class="hljs-comment">//=&gt; false</span>
+R.containsWith(absEq, <span class="hljs-number">5</span>, [-<span class="hljs-number">4</span>, -<span class="hljs-number">5</span>, -<span class="hljs-number">6</span>]); <span class="hljs-comment">//=&gt; true</span></code></pre>
         </section>
         <section class="card" id="converge">
             <h2>
                 <a tabindex="2" class="name" href="#converge">converge</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/converge.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/converge.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3444,7 +3531,7 @@ R.containsWith(<span class="hljs-function"><span class="hljs-keyword">function</
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-converge">
                     <span class="caret rotated"></span>
-                    (x1 → x2 → … → z) → ((a → b → … → x1), (a → b → … → x2), …) → (a → b → … → z)
+                    (x1 → x2 → … → z) → [(a → b → … → x1), (a → b → … → x2), …] → (a → b → … → z)
                 </button>
             </div>
 
@@ -3458,9 +3545,9 @@ R.containsWith(<span class="hljs-function"><span class="hljs-keyword">function</
 </span>
                     </li>
                     <li class="list-group-item">
-                        <span class="type">function</span>
+                        <span class="type">Array</span>
                         <span class="name">functions</span>
-                        <span class="description"><p>A variable number of functions.</p>
+                        <span class="description"><p>A list of functions.</p>
 </span>
                     </li>
                 </ul>
@@ -3472,29 +3559,30 @@ R.containsWith(<span class="hljs-function"><span class="hljs-keyword">function</
                 </div>
             </div>
 
-            <div class="description"><p>Accepts at least three functions and returns a new function. When invoked, this new
-function will invoke the first function, <code>after</code>, passing as its arguments the
-results of invoking the subsequent functions with whatever arguments are passed to
-the new function.</p>
+            <div class="description"><p>Accepts a converging function and a list of branching functions and returns a new function.
+When invoked, this new function is applied to some arguments, each branching
+function is applied to those same arguments. The results of each branching
+function are passed as arguments to the converging function to produce the return value.</p>
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> add = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{ <span class="hljs-keyword">return</span> a + b; };
-<span class="hljs-keyword">var</span> multiply = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{ <span class="hljs-keyword">return</span> a * b; };
-<span class="hljs-keyword">var</span> subtract = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{ <span class="hljs-keyword">return</span> a - b; };
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> add = (a, b) =&gt; a + b;
+<span class="hljs-keyword">var</span> multiply = (a, b) =&gt; a * b;
+<span class="hljs-keyword">var</span> subtract = (a, b) =&gt; a - b;
 
 <span class="hljs-comment">//≅ multiply( add(1, 2), subtract(1, 2) );</span>
-R.converge(multiply, add, subtract)(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>); <span class="hljs-comment">//=&gt; -3</span>
+R.converge(multiply, [add, subtract])(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>); <span class="hljs-comment">//=&gt; -3</span>
 
-<span class="hljs-keyword">var</span> add3 = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b, c</span>) </span>{ <span class="hljs-keyword">return</span> a + b + c; };
-R.converge(add3, multiply, add, subtract)(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>); <span class="hljs-comment">//=&gt; 4</span></code></pre>
+<span class="hljs-keyword">var</span> add3 = (a, b, c) =&gt; a + b + c;
+R.converge(add3, [multiply, add, subtract])(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>); <span class="hljs-comment">//=&gt; 4</span></code></pre>
         </section>
         <section class="card" id="countBy">
             <h2>
                 <a tabindex="2" class="name" href="#countBy">countBy</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/countBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/countBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3548,10 +3636,13 @@ R.countBy(R.toLower)(letters);   <span class="hljs-comment">//=&gt; {'a': 5, 'b'
                 <a tabindex="2" class="name" href="#createMapEntry">createMapEntry</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/createMapEntry.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/createMapEntry.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
+            <div class="deprecated">
+                Deprecated since v0.18.0
+            </div>
 
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-createMapEntry">
@@ -3584,6 +3675,11 @@ R.countBy(R.toLower)(letters);   <span class="hljs-comment">//=&gt; {'a': 5, 'b'
 </div>
 
 
+            <div class="see">
+                See also
+                <a href="#pair">pair</a>,
+                <a href="#objOf">objOf</a>.
+            </div>
 
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> matchPhrases = R.compose(
   R.createMapEntry(<span class="hljs-string">'must'</span>),
@@ -3596,7 +3692,7 @@ matchPhrases([<span class="hljs-string">'foo'</span>, <span class="hljs-string">
                 <a tabindex="2" class="name" href="#curry">curry</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/curry.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/curry.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3656,9 +3752,7 @@ the following are equivalent:</p>
                 <a href="#curryN">curryN</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> addFourNumbers = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b, c, d</span>) </span>{
-  <span class="hljs-keyword">return</span> a + b + c + d;
-};
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> addFourNumbers = (a, b, c, d) =&gt; a + b + c + d;
 
 <span class="hljs-keyword">var</span> curriedAddFourNumbers = R.curry(addFourNumbers);
 <span class="hljs-keyword">var</span> f = curriedAddFourNumbers(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>);
@@ -3670,7 +3764,7 @@ g(<span class="hljs-number">4</span>); <span class="hljs-comment">//=&gt; 10</sp
                 <a tabindex="2" class="name" href="#curryN">curryN</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/curryN.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/curryN.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3736,11 +3830,9 @@ the following are equivalent:</p>
                 <a href="#curry">curry</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> addFourNumbers = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
-  <span class="hljs-keyword">return</span> R.sum([].slice.call(<span class="hljs-built_in">arguments</span>, <span class="hljs-number">0</span>, <span class="hljs-number">4</span>));
-};
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> sumArgs = (...args) =&gt; R.sum(args);
 
-<span class="hljs-keyword">var</span> curriedAddFourNumbers = R.curryN(<span class="hljs-number">4</span>, addFourNumbers);
+<span class="hljs-keyword">var</span> curriedAddFourNumbers = R.curryN(<span class="hljs-number">4</span>, sumArgs);
 <span class="hljs-keyword">var</span> f = curriedAddFourNumbers(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>);
 <span class="hljs-keyword">var</span> g = f(<span class="hljs-number">3</span>);
 g(<span class="hljs-number">4</span>); <span class="hljs-comment">//=&gt; 10</span></code></pre>
@@ -3750,7 +3842,7 @@ g(<span class="hljs-number">4</span>); <span class="hljs-comment">//=&gt; 10</sp
                 <a tabindex="2" class="name" href="#dec">dec</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/dec.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/dec.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3793,7 +3885,7 @@ g(<span class="hljs-number">4</span>); <span class="hljs-comment">//=&gt; 10</sp
                 <a tabindex="2" class="name" href="#defaultTo">defaultTo</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/defaultTo.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/defaultTo.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3828,8 +3920,8 @@ g(<span class="hljs-number">4</span>); <span class="hljs-comment">//=&gt; 10</sp
                 </div>
             </div>
 
-            <div class="description"><p>Returns the second argument if it is not null or undefined. If it is null
-or undefined, the first (default) argument is returned.</p>
+            <div class="description"><p>Returns the second argument if it is not <code>null</code>, <code>undefined</code> or <code>NaN</code>
+otherwise the first argument is returned.</p>
 </div>
 
 
@@ -3838,14 +3930,15 @@ or undefined, the first (default) argument is returned.</p>
 
 defaultTo42(<span class="hljs-literal">null</span>);  <span class="hljs-comment">//=&gt; 42</span>
 defaultTo42(<span class="hljs-literal">undefined</span>);  <span class="hljs-comment">//=&gt; 42</span>
-defaultTo42(<span class="hljs-string">'Ramda'</span>);  <span class="hljs-comment">//=&gt; 'Ramda'</span></code></pre>
+defaultTo42(<span class="hljs-string">'Ramda'</span>);  <span class="hljs-comment">//=&gt; 'Ramda'</span>
+defaultTo42(<span class="hljs-built_in">parseInt</span>(<span class="hljs-string">'string'</span>)); <span class="hljs-comment">//=&gt; 42</span></code></pre>
         </section>
         <section class="card" id="difference">
             <h2>
                 <a tabindex="2" class="name" href="#difference">difference</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/difference.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/difference.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3897,7 +3990,7 @@ R.difference([<span class="hljs-number">7</span>,<span class="hljs-number">6</sp
                 <a tabindex="2" class="name" href="#differenceWith">differenceWith</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/differenceWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/differenceWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -3949,17 +4042,17 @@ elements.</p>
                 <a href="#difference">difference</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">cmp</span>(<span class="hljs-params">x, y</span>) </span>{ <span class="hljs-keyword">return</span> x.a === y.a; }
-<span class="hljs-keyword">var</span> l1 = [{a: <span class="hljs-number">1</span>}, {a: <span class="hljs-number">2</span>}, {a: <span class="hljs-number">3</span>}];
-<span class="hljs-keyword">var</span> l2 = [{a: <span class="hljs-number">3</span>}, {a: <span class="hljs-number">4</span>}];
-R.differenceWith(cmp, l1, l2); <span class="hljs-comment">//=&gt; [{a: 1}, {a: 2}]</span></code></pre>
+            <pre><code class="hljs javascript">function cmp(x, y) =&gt; x.a === y.a;
+var l1 = [{a: 1}, {a: 2}, {a: 3}];
+var l2 = [{a: 3}, {a: 4}];
+R.differenceWith(cmp, l1, l2); //=&gt; [{a: 1}, {a: 2}]</code></pre>
         </section>
         <section class="card" id="dissoc">
             <h2>
                 <a tabindex="2" class="name" href="#dissoc">dissoc</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/dissoc.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/dissoc.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4010,7 +4103,7 @@ R.differenceWith(cmp, l1, l2); <span class="hljs-comment">//=&gt; [{a: 1}, {a: 2
                 <a tabindex="2" class="name" href="#dissocPath">dissocPath</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/dissocPath.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/dissocPath.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4064,7 +4157,7 @@ by reference.</p>
                 <a tabindex="2" class="name" href="#divide">divide</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/divide.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/divide.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4121,7 +4214,7 @@ reciprocal(<span class="hljs-number">4</span>);   <span class="hljs-comment">//=
                 <a tabindex="2" class="name" href="#drop">drop</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/drop.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/drop.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4155,6 +4248,7 @@ reciprocal(<span class="hljs-number">4</span>);   <span class="hljs-comment">//=
 
             <div class="description"><p>Returns all but the first <code>n</code> elements of the given list, string, or
 transducer/transformer (or object with a <code>drop</code> method).</p>
+<p>Dispatches to the <code>drop</code> method of the second argument, if present.</p>
 </div>
 
 
@@ -4175,7 +4269,7 @@ R.drop(<span class="hljs-number">3</span>, <span class="hljs-string">'ramda'</sp
                 <a tabindex="2" class="name" href="#dropLast">dropLast</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/dropLast.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/dropLast.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4229,7 +4323,7 @@ R.dropLast(<span class="hljs-number">3</span>, <span class="hljs-string">'ramda'
                 <a tabindex="2" class="name" href="#dropLastWhile">dropLastWhile</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/dropLastWhile.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/dropLastWhile.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4276,18 +4370,16 @@ is passed one argument: (value)*.</p>
                 <a href="#takeLastWhile">takeLastWhile</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> lteThree = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{
-  <span class="hljs-keyword">return</span> x &lt;= <span class="hljs-number">3</span>;
-};
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> lteThree = x =&gt; x &lt;= <span class="hljs-number">3</span>;
 
-R.dropLastWhile(lteThree, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">3</span>, <span class="hljs-number">2</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">//=&gt; [1, 2]</span></code></pre>
+R.dropLastWhile(lteThree, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">3</span>, <span class="hljs-number">2</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">//=&gt; [1, 2, 3, 4]</span></code></pre>
         </section>
         <section class="card" id="dropRepeats">
             <h2>
                 <a tabindex="2" class="name" href="#dropRepeats">dropRepeats</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/dropRepeats.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/dropRepeats.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4318,6 +4410,7 @@ R.dropLastWhile(lteThree, [<span class="hljs-number">1</span>, <span class="hljs
 
             <div class="description"><p>Returns a new list without any consecutively repeating elements.
 <code>R.equals</code> is used to determine equality.</p>
+<p>Dispatches to the <code>dropRepeats</code> method of the first argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
@@ -4334,7 +4427,7 @@ R.dropLastWhile(lteThree, [<span class="hljs-number">1</span>, <span class="hljs
                 <a tabindex="2" class="name" href="#dropRepeatsWith">dropRepeatsWith</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/dropRepeatsWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/dropRepeatsWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4372,6 +4465,7 @@ R.dropLastWhile(lteThree, [<span class="hljs-number">1</span>, <span class="hljs
             <div class="description"><p>Returns a new list without any consecutively repeating elements. Equality is
 determined by applying the supplied predicate two consecutive elements.
 The first element in a series of equal element is the one being preserved.</p>
+<p>Dispatches to the <code>dropRepeatsWith</code> method of the second argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
@@ -4381,16 +4475,16 @@ The first element in a series of equal element is the one being preserved.</p>
                 <a href="#transduce">transduce</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">lengthEq</span>(<span class="hljs-params">x, y</span>) </span>{ <span class="hljs-keyword">return</span> <span class="hljs-built_in">Math</span>.abs(x) === <span class="hljs-built_in">Math</span>.abs(y); };
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> lengthEq = (x, y) =&gt; <span class="hljs-built_in">Math</span>.abs(x) === <span class="hljs-built_in">Math</span>.abs(y);
 <span class="hljs-keyword">var</span> l = [<span class="hljs-number">1</span>, -<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, -<span class="hljs-number">4</span>, -<span class="hljs-number">4</span>, -<span class="hljs-number">5</span>, <span class="hljs-number">5</span>, <span class="hljs-number">3</span>, <span class="hljs-number">3</span>];
-R.dropRepeatsWith(lengthEq, l); <span class="hljs-comment">//=&gt; [1, 3, 4, -5, 3]</span></code></pre>
+R.dropRepeatsWith(R.eqBy(<span class="hljs-built_in">Math</span>.abs), l); <span class="hljs-comment">//=&gt; [1, 3, 4, -5, 3]</span></code></pre>
         </section>
         <section class="card" id="dropWhile">
             <h2>
                 <a tabindex="2" class="name" href="#dropWhile">dropWhile</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/dropWhile.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/dropWhile.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4428,6 +4522,7 @@ R.dropRepeatsWith(lengthEq, l); <span class="hljs-comment">//=&gt; [1, 3, 4, -5,
             <div class="description"><p>Returns a new list containing the last <code>n</code> elements of a given list, passing each value
 to the supplied predicate function, skipping elements while the predicate function returns
 <code>true</code>. The predicate function is passed one argument: <em>(value)</em>.</p>
+<p>Dispatches to the <code>dropWhile</code> method of the second argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
@@ -4438,9 +4533,7 @@ to the supplied predicate function, skipping elements while the predicate functi
                 <a href="#takeWhile">takeWhile</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> lteTwo = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{
-  <span class="hljs-keyword">return</span> x &lt;= <span class="hljs-number">2</span>;
-};
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> lteTwo = x =&gt; x &lt;= <span class="hljs-number">2</span>;
 
 R.dropWhile(lteTwo, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">3</span>, <span class="hljs-number">2</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">//=&gt; [3, 4, 3, 2, 1]</span></code></pre>
         </section>
@@ -4449,7 +4542,7 @@ R.dropWhile(lteTwo, [<span class="hljs-number">1</span>, <span class="hljs-numbe
                 <a tabindex="2" class="name" href="#either">either</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/either.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/either.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4485,9 +4578,8 @@ R.dropWhile(lteTwo, [<span class="hljs-number">1</span>, <span class="hljs-numbe
             </div>
 
             <div class="description"><p>A function wrapping calls to the two functions in an <code>||</code> operation, returning the result of the first
-function if it is truth-y and the result of the second function otherwise.  Note that this is
-short-circuited, meaning that the second function will not be invoked if the first returns a truth-y
-value.</p>
+function if it is truth-y and the result of the second function otherwise.</p>
+<p><code>R.either</code> will work on all other applicatives as well.</p>
 </div>
 
 
@@ -4496,8 +4588,8 @@ value.</p>
                 <a href="#or">or</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> gt10 = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{ <span class="hljs-keyword">return</span> x &gt; <span class="hljs-number">10</span>; };
-<span class="hljs-keyword">var</span> even = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{ <span class="hljs-keyword">return</span> x % <span class="hljs-number">2</span> === <span class="hljs-number">0</span> };
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> gt10 = x =&gt; x &gt; <span class="hljs-number">10</span>;
+<span class="hljs-keyword">var</span> even = x =&gt; x % <span class="hljs-number">2</span> === <span class="hljs-number">0</span>;
 <span class="hljs-keyword">var</span> f = R.either(gt10, even);
 f(<span class="hljs-number">101</span>); <span class="hljs-comment">//=&gt; true</span>
 f(<span class="hljs-number">8</span>); <span class="hljs-comment">//=&gt; true</span></code></pre>
@@ -4507,7 +4599,7 @@ f(<span class="hljs-number">8</span>); <span class="hljs-comment">//=&gt; true</
                 <a tabindex="2" class="name" href="#empty">empty</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/empty.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/empty.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4535,8 +4627,10 @@ f(<span class="hljs-number">8</span>); <span class="hljs-comment">//=&gt; true</
             </div>
 
             <div class="description"><p>Returns the empty value of its argument&#39;s type. Ramda defines the empty
-value of Array (<code>[]</code>), Object (<code>{}</code>), and String (<code>&#39;&#39;</code>). Other types are
-supported if they define <code>&lt;Type&gt;.empty</code> and/or <code>&lt;Type&gt;.prototype.empty</code>.</p>
+value of Array (<code>[]</code>), Object (<code>{}</code>), String (<code>&#39;&#39;</code>), and Arguments.
+Other types are supported if they define <code>&lt;Type&gt;.empty</code> and/or
+<code>&lt;Type&gt;.prototype.empty</code>.</p>
+<p>Dispatches to the <code>empty</code> method of the first argument, if present.</p>
 </div>
 
 
@@ -4546,12 +4640,62 @@ R.empty([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>,
 R.empty(<span class="hljs-string">'unicorns'</span>);    <span class="hljs-comment">//=&gt; ''</span>
 R.empty({x: <span class="hljs-number">1</span>, y: <span class="hljs-number">2</span>});  <span class="hljs-comment">//=&gt; {}</span></code></pre>
         </section>
+        <section class="card" id="eqBy">
+            <h2>
+                <a tabindex="2" class="name" href="#eqBy">eqBy</a>
+                <span class="pull-right">
+                        <span class="label label-category">Relation</span>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/eqBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                </span>
+            </h2>
+
+
+            <div>
+                <button class="sig btn btn-link" data-collapser="#__details-eqBy">
+                    <span class="caret rotated"></span>
+                    (a → b) → a → a → Boolean
+                </button>
+            </div>
+
+            <div class="details collapse panel panel-default" id="__details-eqBy">
+                <ul class="list-group">
+                    <li class="list-group-item">
+                        <span class="type">function</span>
+                        <span class="name">f</span>
+                        <span class="description"></span>
+                    </li>
+                    <li class="list-group-item">
+                        <span class="type">*</span>
+                        <span class="name">x</span>
+                        <span class="description"></span>
+                    </li>
+                    <li class="list-group-item">
+                        <span class="type">*</span>
+                        <span class="name">y</span>
+                        <span class="description"></span>
+                    </li>
+                </ul>
+                <div class="panel-body">
+                    <span class="returns">Returns</span>
+                    <span class="type">Boolean</span>
+                    <span class="description"></span>
+                </div>
+            </div>
+
+            <div class="description"><p>Takes a function and two values in its domain and returns <code>true</code> if
+the values map to the same value in the codomain; <code>false</code> otherwise.</p>
+</div>
+
+
+
+            <pre><code class="hljs javascript">R.eqBy(<span class="hljs-built_in">Math</span>.abs, <span class="hljs-number">5</span>, -<span class="hljs-number">5</span>); <span class="hljs-comment">//=&gt; true</span></code></pre>
+        </section>
         <section class="card" id="eqProps">
             <h2>
                 <a tabindex="2" class="name" href="#eqProps">eqProps</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/eqProps.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/eqProps.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4605,7 +4749,7 @@ R.eqProps(<span class="hljs-string">'c'</span>, o1, o2); <span class="hljs-comme
                 <a tabindex="2" class="name" href="#equals">equals</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/equals.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/equals.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4640,6 +4784,7 @@ R.eqProps(<span class="hljs-string">'c'</span>, o1, o2); <span class="hljs-comme
             <div class="description"><p>Returns <code>true</code> if its arguments are equivalent, <code>false</code> otherwise.
 Dispatches to an <code>equals</code> method if present. Handles cyclical data
 structures.</p>
+<p>Dispatches to the <code>equals</code> method of both arguments, if present.</p>
 </div>
 
 
@@ -4657,7 +4802,7 @@ R.equals(a, b); <span class="hljs-comment">//=&gt; true</span></code></pre>
                 <a tabindex="2" class="name" href="#evolve">evolve</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/evolve.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/evolve.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4695,7 +4840,7 @@ R.equals(a, b); <span class="hljs-comment">//=&gt; true</span></code></pre>
 
             <div class="description"><p>Creates a new object by recursively evolving a shallow copy of <code>object</code>, according to the
 <code>transformation</code> functions. All non-primitive properties are copied by reference.</p>
-<p>A <code>tranformation</code> function will not be invoked if its corresponding key does not exist in
+<p>A <code>transformation</code> function will not be invoked if its corresponding key does not exist in
 the evolved object.</p>
 </div>
 
@@ -4714,7 +4859,7 @@ R.evolve(transformations, tomato); <span class="hljs-comment">//=&gt; {firstName
                 <a tabindex="2" class="name" href="#F">F</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/F.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/F.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4722,18 +4867,22 @@ R.evolve(transformations, tomato); <span class="hljs-comment">//=&gt; {firstName
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-F">
                     <span class="caret rotated"></span>
-                    * → false
+                    * → Boolean
                 </button>
             </div>
 
             <div class="details collapse panel panel-default" id="__details-F">
                 <ul class="list-group">
+                    <li class="list-group-item">
+                        <span class="type">*</span>
+                        <span class="name"></span>
+                        <span class="description"></span>
+                    </li>
                 </ul>
                 <div class="panel-body">
                     <span class="returns">Returns</span>
                     <span class="type">Boolean</span>
-                    <span class="description"><p>false</p>
-</span>
+                    <span class="description"></span>
                 </div>
             </div>
 
@@ -4754,7 +4903,7 @@ R.evolve(transformations, tomato); <span class="hljs-comment">//=&gt; {firstName
                 <a tabindex="2" class="name" href="#filter">filter</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/filter.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/filter.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4794,6 +4943,7 @@ The predicate function is passed one argument: <em>(value)</em>.</p>
 <p>Note that <code>R.filter</code> does not skip deleted or unassigned indices, unlike the native
 <code>Array.prototype.filter</code> method. For more details on this behavior, see:
 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#Description">https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#Description</a></p>
+<p>Dispatches to the <code>filter</code> method of the second argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
@@ -4804,9 +4954,8 @@ The predicate function is passed one argument: <em>(value)</em>.</p>
                 <a href="#reject">reject</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isEven = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">n</span>) </span>{
-  <span class="hljs-keyword">return</span> n % <span class="hljs-number">2</span> === <span class="hljs-number">0</span>;
-};
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isEven = n =&gt; n % <span class="hljs-number">2</span> === <span class="hljs-number">0</span>;
+
 R.filter(isEven, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]); <span class="hljs-comment">//=&gt; [2, 4]</span></code></pre>
         </section>
         <section class="card" id="find">
@@ -4814,7 +4963,7 @@ R.filter(isEven, [<span class="hljs-number">1</span>, <span class="hljs-number">
                 <a tabindex="2" class="name" href="#find">find</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/find.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/find.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4852,6 +5001,7 @@ R.filter(isEven, [<span class="hljs-number">1</span>, <span class="hljs-number">
 
             <div class="description"><p>Returns the first element of the list which matches the predicate, or <code>undefined</code> if no
 element matches.</p>
+<p>Dispatches to the <code>find</code> method of the second argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
@@ -4870,7 +5020,7 @@ R.find(R.propEq(<span class="hljs-string">'a'</span>, <span class="hljs-number">
                 <a tabindex="2" class="name" href="#findIndex">findIndex</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/findIndex.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/findIndex.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4908,6 +5058,7 @@ desired one.</p>
 
             <div class="description"><p>Returns the index of the first element of the list which matches the predicate, or <code>-1</code>
 if no element matches.</p>
+<p>Dispatches to the <code>findIndex</code> method of the second argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
@@ -4926,7 +5077,7 @@ R.findIndex(R.propEq(<span class="hljs-string">'a'</span>, <span class="hljs-num
                 <a tabindex="2" class="name" href="#findLast">findLast</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/findLast.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/findLast.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -4964,6 +5115,7 @@ desired one.</p>
 
             <div class="description"><p>Returns the last element of the list which matches the predicate, or <code>undefined</code> if no
 element matches.</p>
+<p>Dispatches to the <code>findLast</code> method of the second argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
@@ -4982,7 +5134,7 @@ R.findLast(R.propEq(<span class="hljs-string">'a'</span>, <span class="hljs-numb
                 <a tabindex="2" class="name" href="#findLastIndex">findLastIndex</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/findLastIndex.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/findLastIndex.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5020,6 +5172,7 @@ desired one.</p>
 
             <div class="description"><p>Returns the index of the last element of the list which matches the predicate, or
 <code>-1</code> if no element matches.</p>
+<p>Dispatches to the <code>findLastIndex</code> method of the second argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
@@ -5038,7 +5191,7 @@ R.findLastIndex(R.propEq(<span class="hljs-string">'a'</span>, <span class="hljs
                 <a tabindex="2" class="name" href="#flatten">flatten</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/flatten.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/flatten.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5085,7 +5238,7 @@ them in a new array, depth-first.</p>
                 <a tabindex="2" class="name" href="#flip">flip</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/flip.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/flip.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5119,9 +5272,8 @@ order is reversed.</p>
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> mergeThree = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b, c</span>) </span>{
-  <span class="hljs-keyword">return</span> ([]).concat(a, b, c);
-};
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> mergeThree = (a, b, c) =&gt; [].concat(a, b, c);
 
 mergeThree(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>); <span class="hljs-comment">//=&gt; [1, 2, 3]</span>
 
@@ -5132,7 +5284,7 @@ R.flip(mergeThree)(<span class="hljs-number">1</span>, <span class="hljs-number"
                 <a tabindex="2" class="name" href="#forEach">forEach</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/forEach.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/forEach.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5175,10 +5327,12 @@ the native <code>Array.prototype.forEach</code> method. For more details on this
 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#Description">https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#Description</a></p>
 <p>Also note that, unlike <code>Array.prototype.forEach</code>, Ramda&#39;s <code>forEach</code> returns the original
 array. In some libraries this function is named <code>each</code>.</p>
+<p>Dispatches to the <code>forEach</code> method of the second argument, if present.</p>
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> printXPlusFive = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{ <span class="hljs-built_in">console</span>.log(x + <span class="hljs-number">5</span>); };
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> printXPlusFive = x =&gt; <span class="hljs-built_in">console</span>.log(x + <span class="hljs-number">5</span>);
 R.forEach(printXPlusFive, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">//=&gt; [1, 2, 3]</span>
 <span class="hljs-comment">//-&gt; 6</span>
 <span class="hljs-comment">//-&gt; 7</span>
@@ -5189,7 +5343,7 @@ R.forEach(printXPlusFive, [<span class="hljs-number">1</span>, <span class="hljs
                 <a tabindex="2" class="name" href="#fromPairs">fromPairs</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/fromPairs.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/fromPairs.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5224,7 +5378,8 @@ R.forEach(printXPlusFive, [<span class="hljs-number">1</span>, <span class="hljs
 
             <div class="see">
                 See also
-                <a href="#toPairs">toPairs</a>.
+                <a href="#toPairs">toPairs</a>,
+                <a href="#pair">pair</a>.
             </div>
 
             <pre><code class="hljs javascript">R.fromPairs([[<span class="hljs-string">'a'</span>, <span class="hljs-number">1</span>], [<span class="hljs-string">'b'</span>, <span class="hljs-number">2</span>],  [<span class="hljs-string">'c'</span>, <span class="hljs-number">3</span>]]); <span class="hljs-comment">//=&gt; {a: 1, b: 2, c: 3}</span></code></pre>
@@ -5234,10 +5389,13 @@ R.forEach(printXPlusFive, [<span class="hljs-number">1</span>, <span class="hljs
                 <a tabindex="2" class="name" href="#functions">functions</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/functions.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/functions.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
+            <div class="deprecated">
+                Deprecated since v0.18.0
+            </div>
 
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-functions">
@@ -5280,10 +5438,13 @@ R.functions(<span class="hljs-keyword">new</span> F()); <span class="hljs-commen
                 <a tabindex="2" class="name" href="#functionsIn">functionsIn</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/functionsIn.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/functionsIn.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
+            <div class="deprecated">
+                Deprecated since v0.18.0
+            </div>
 
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-functionsIn">
@@ -5327,7 +5488,7 @@ R.functionsIn(<span class="hljs-keyword">new</span> F()); <span class="hljs-comm
                 <a tabindex="2" class="name" href="#groupBy">groupBy</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/groupBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/groupBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5365,6 +5526,7 @@ R.functionsIn(<span class="hljs-keyword">new</span> F()); <span class="hljs-comm
 
             <div class="description"><p>Splits a list into sub-lists stored in an object, based on the result of calling a String-returning function
 on each element, and grouping the results according to values returned.</p>
+<p>Dispatches to the <code>groupBy</code> method of the second argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
@@ -5398,7 +5560,7 @@ byGrade(students);
                 <a tabindex="2" class="name" href="#gt">gt</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/gt.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/gt.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5451,7 +5613,7 @@ R.gt(<span class="hljs-string">'z'</span>, <span class="hljs-string">'a'</span>)
                 <a tabindex="2" class="name" href="#gte">gte</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/gte.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/gte.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5504,7 +5666,7 @@ R.gte(<span class="hljs-string">'z'</span>, <span class="hljs-string">'a'</span>
                 <a tabindex="2" class="name" href="#has">has</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/has.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/has.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5561,7 +5723,7 @@ pointHas(<span class="hljs-string">'z'</span>);  <span class="hljs-comment">//=&
                 <a tabindex="2" class="name" href="#hasIn">hasIn</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/hasIn.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/hasIn.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5601,6 +5763,7 @@ a property with the specified name</p>
 </div>
 
 
+
             <pre><code class="hljs javascript"><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">Rectangle</span>(<span class="hljs-params">width, height</span>) </span>{
   <span class="hljs-keyword">this</span>.width = width;
   <span class="hljs-keyword">this</span>.height = height;
@@ -5618,7 +5781,7 @@ R.hasIn(<span class="hljs-string">'area'</span>, square);  <span class="hljs-com
                 <a tabindex="2" class="name" href="#head">head</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/head.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/head.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5668,7 +5831,7 @@ R.head(<span class="hljs-string">''</span>); <span class="hljs-comment">//=&gt; 
                 <a tabindex="2" class="name" href="#identical">identical</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/identical.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/identical.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5720,7 +5883,7 @@ R.identical(<span class="hljs-literal">NaN</span>, <span class="hljs-literal">Na
                 <a tabindex="2" class="name" href="#identity">identity</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/identity.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/identity.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5765,7 +5928,7 @@ R.identity(obj) === obj; <span class="hljs-comment">//=&gt; true</span></code></
                 <a tabindex="2" class="name" href="#ifElse">ifElse</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/ifElse.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/ifElse.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5812,19 +5975,26 @@ upon the result of the <code>condition</code> predicate.</p>
 </div>
 
 
+            <div class="see">
+                See also
+                <a href="#unless">unless</a>,
+                <a href="#when">when</a>.
+            </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-comment">// Flatten all arrays in the list but leave other values alone.</span>
-<span class="hljs-keyword">var</span> flattenArrays = R.map(R.ifElse(<span class="hljs-built_in">Array</span>.isArray, R.flatten, R.identity));
-
-flattenArrays([[<span class="hljs-number">0</span>], [[<span class="hljs-number">10</span>], [<span class="hljs-number">8</span>]], <span class="hljs-number">1234</span>, {}]); <span class="hljs-comment">//=&gt; [[0], [10, 8], 1234, {}]</span>
-flattenArrays([[[<span class="hljs-number">10</span>], <span class="hljs-number">123</span>], [<span class="hljs-number">8</span>, [<span class="hljs-number">10</span>]], <span class="hljs-string">"hello"</span>]); <span class="hljs-comment">//=&gt; [[10, 123], [8, 10], "hello"]</span></code></pre>
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> incCount = R.ifElse(
+  R.has(<span class="hljs-string">'count'</span>),
+  R.over(R.lensProp(<span class="hljs-string">'count'</span>), R.inc),
+  R.assoc(<span class="hljs-string">'count'</span>, <span class="hljs-number">1</span>)
+);
+incCount({});           <span class="hljs-comment">//=&gt; { count: 1 }</span>
+incCount({ count: <span class="hljs-number">1</span> }); <span class="hljs-comment">//=&gt; { count: 2 }</span></code></pre>
         </section>
         <section class="card" id="inc">
             <h2>
                 <a tabindex="2" class="name" href="#inc">inc</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/inc.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/inc.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5867,7 +6037,7 @@ flattenArrays([[[<span class="hljs-number">10</span>], <span class="hljs-number"
                 <a tabindex="2" class="name" href="#indexOf">indexOf</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/indexOf.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/indexOf.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5921,7 +6091,7 @@ R.indexOf(<span class="hljs-number">10</span>, [<span class="hljs-number">1</spa
                 <a tabindex="2" class="name" href="#init">init</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/init.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/init.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -5974,7 +6144,7 @@ R.init(<span class="hljs-string">''</span>);     <span class="hljs-comment">//=&
                 <a tabindex="2" class="name" href="#insert">insert</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/insert.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/insert.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6029,7 +6199,7 @@ that this is not destructive</em>: it returns a copy of the list with the change
                 <a tabindex="2" class="name" href="#insertAll">insertAll</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/insertAll.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/insertAll.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6084,7 +6254,7 @@ is not destructive</em>: it returns a copy of the list with the changes.
                 <a tabindex="2" class="name" href="#intersection">intersection</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/intersection.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/intersection.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6135,7 +6305,7 @@ is not destructive</em>: it returns a copy of the list with the changes.
                 <a tabindex="2" class="name" href="#intersectionWith">intersectionWith</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/intersectionWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/intersectionWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6203,9 +6373,7 @@ elements.</p>
   {id: <span class="hljs-number">177</span>, name: <span class="hljs-string">'Neil Young'</span>}
 ];
 
-<span class="hljs-keyword">var</span> sameId = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">o1, o2</span>) </span>{<span class="hljs-keyword">return</span> o1.id === o2.id;};
-
-R.intersectionWith(sameId, buffaloSpringfield, csny);
+R.intersectionWith(R.eqBy(R.prop(<span class="hljs-string">'id'</span>)), buffaloSpringfield, csny);
 <span class="hljs-comment">//=&gt; [{id: 456, name: 'Stephen Stills'}, {id: 177, name: 'Neil Young'}]</span></code></pre>
         </section>
         <section class="card" id="intersperse">
@@ -6213,7 +6381,7 @@ R.intersectionWith(sameId, buffaloSpringfield, csny);
                 <a tabindex="2" class="name" href="#intersperse">intersperse</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/intersperse.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/intersperse.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6249,6 +6417,7 @@ R.intersectionWith(sameId, buffaloSpringfield, csny);
             </div>
 
             <div class="description"><p>Creates a new list with the separator interposed between elements.</p>
+<p>Dispatches to the <code>intersperse</code> method of the second argument, if present.</p>
 </div>
 
 
@@ -6260,7 +6429,7 @@ R.intersectionWith(sameId, buffaloSpringfield, csny);
                 <a tabindex="2" class="name" href="#into">into</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/into.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/into.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6329,7 +6498,7 @@ intoArray(transducer, numbers); <span class="hljs-comment">//=&gt; [2, 3]</span>
                 <a tabindex="2" class="name" href="#invert">invert</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/invert.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/invert.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6379,7 +6548,7 @@ R.invert(raceResultsByFirstName);
                 <a tabindex="2" class="name" href="#invertObj">invertObj</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/invertObj.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/invertObj.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6409,7 +6578,10 @@ R.invert(raceResultsByFirstName);
             </div>
 
             <div class="description"><p>Returns a new object with the keys of the given object
-as values, and the values of the given object as keys.</p>
+as values, and the values of the given object, which are
+coerced to strings, as keys.
+Note that the last key found is preferred when handling
+the same value.</p>
 </div>
 
 
@@ -6431,7 +6603,7 @@ R.invertObj(raceResults);
                 <a tabindex="2" class="name" href="#invoker">invoker</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/invoker.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/invoker.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6485,7 +6657,7 @@ sliceFrom6(<span class="hljs-number">8</span>, <span class="hljs-string">'abcdef
                 <a tabindex="2" class="name" href="#is">is</a>
                 <span class="pull-right">
                         <span class="label label-category">Type</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/is.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/is.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6539,7 +6711,7 @@ R.is(<span class="hljs-built_in">Number</span>, {}); <span class="hljs-comment">
                 <a tabindex="2" class="name" href="#isArrayLike">isArrayLike</a>
                 <span class="pull-right">
                         <span class="label label-category">Type</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/isArrayLike.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/isArrayLike.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6584,7 +6756,7 @@ R.isArrayLike({<span class="hljs-number">0</span>: <span class="hljs-string">'ze
                 <a tabindex="2" class="name" href="#isEmpty">isEmpty</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/isEmpty.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/isEmpty.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6592,15 +6764,15 @@ R.isArrayLike({<span class="hljs-number">0</span>: <span class="hljs-string">'ze
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-isEmpty">
                     <span class="caret rotated"></span>
-                    [a] → Boolean
+                    a → Boolean
                 </button>
             </div>
 
             <div class="details collapse panel panel-default" id="__details-isEmpty">
                 <ul class="list-group">
                     <li class="list-group-item">
-                        <span class="type">Array</span>
-                        <span class="name">list</span>
+                        <span class="type">*</span>
+                        <span class="name">x</span>
                         <span class="description"></span>
                     </li>
                 </ul>
@@ -6611,25 +6783,29 @@ R.isArrayLike({<span class="hljs-number">0</span>: <span class="hljs-string">'ze
                 </div>
             </div>
 
-            <div class="description"><p>Reports whether the list has zero elements.</p>
+            <div class="description"><p>Returns <code>true</code> if the given value is its type&#39;s empty value; <code>false</code>
+otherwise.</p>
 </div>
 
 
+            <div class="see">
+                See also
+                <a href="#empty">empty</a>.
+            </div>
 
             <pre><code class="hljs javascript">R.isEmpty([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]);   <span class="hljs-comment">//=&gt; false</span>
 R.isEmpty([]);          <span class="hljs-comment">//=&gt; true</span>
 R.isEmpty(<span class="hljs-string">''</span>);          <span class="hljs-comment">//=&gt; true</span>
 R.isEmpty(<span class="hljs-literal">null</span>);        <span class="hljs-comment">//=&gt; false</span>
-R.isEmpty(R.keys({}));  <span class="hljs-comment">//=&gt; true</span>
-R.isEmpty({});          <span class="hljs-comment">//=&gt; false ({} does not have a length property)</span>
-R.isEmpty({length: <span class="hljs-number">0</span>}); <span class="hljs-comment">//=&gt; true</span></code></pre>
+R.isEmpty({});          <span class="hljs-comment">//=&gt; true</span>
+R.isEmpty({length: <span class="hljs-number">0</span>}); <span class="hljs-comment">//=&gt; false</span></code></pre>
         </section>
         <section class="card" id="isNil">
             <h2>
                 <a tabindex="2" class="name" href="#isNil">isNil</a>
                 <span class="pull-right">
                         <span class="label label-category">Type</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/isNil.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/isNil.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6673,10 +6849,13 @@ R.isNil([]); <span class="hljs-comment">//=&gt; false</span></code></pre>
                 <a tabindex="2" class="name" href="#isSet">isSet</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/isSet.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/isSet.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
+            <div class="deprecated">
+                Deprecated since v0.18.0
+            </div>
 
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-isSet">
@@ -6707,6 +6886,10 @@ otherwise <code>false</code>.</p>
 </div>
 
 
+            <div class="see">
+                See also
+                <a href="#allUniq">allUniq</a>.
+            </div>
 
             <pre><code class="hljs javascript">R.isSet([<span class="hljs-string">'1'</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">//=&gt; true</span>
 R.isSet([<span class="hljs-number">1</span>, <span class="hljs-number">1</span>]);   <span class="hljs-comment">//=&gt; false</span>
@@ -6717,7 +6900,7 @@ R.isSet([[<span class="hljs-number">42</span>], [<span class="hljs-number">42</s
                 <a tabindex="2" class="name" href="#join">join</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/join.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/join.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6771,7 +6954,7 @@ R.join(<span class="hljs-string">'|'</span>, [<span class="hljs-number">1</span>
                 <a tabindex="2" class="name" href="#keys">keys</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/keys.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/keys.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6815,7 +6998,7 @@ consistent across different JS platforms.</p>
                 <a tabindex="2" class="name" href="#keysIn">keysIn</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/keysIn.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/keysIn.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6851,6 +7034,7 @@ consistent across different JS platforms.</p>
 </div>
 
 
+
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> F = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{ <span class="hljs-keyword">this</span>.x = <span class="hljs-string">'X'</span>; };
 F.prototype.y = <span class="hljs-string">'Y'</span>;
 <span class="hljs-keyword">var</span> f = <span class="hljs-keyword">new</span> F();
@@ -6861,7 +7045,7 @@ R.keysIn(f); <span class="hljs-comment">//=&gt; ['x', 'y']</span></code></pre>
                 <a tabindex="2" class="name" href="#last">last</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/last.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/last.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6910,7 +7094,7 @@ R.last(<span class="hljs-string">''</span>); <span class="hljs-comment">//=&gt; 
                 <a tabindex="2" class="name" href="#lastIndexOf">lastIndexOf</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/lastIndexOf.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/lastIndexOf.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -6964,7 +7148,7 @@ R.lastIndexOf(<span class="hljs-number">10</span>, [<span class="hljs-number">1<
                 <a tabindex="2" class="name" href="#length">length</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/length.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/length.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7006,7 +7190,7 @@ R.length([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>
                 <a tabindex="2" class="name" href="#lens">lens</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/lens.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/lens.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7043,6 +7227,7 @@ the value of the focus; the setter &quot;sets&quot; the value of the focus. The 
 should not mutate the data structure.</p>
 </div>
 
+
             <div class="see">
                 See also
                 <a href="#view">view</a>,
@@ -7063,7 +7248,7 @@ R.over(xLens, R.negate, {x: <span class="hljs-number">1</span>, y: <span class="
                 <a tabindex="2" class="name" href="#lensIndex">lensIndex</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/lensIndex.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/lensIndex.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7092,6 +7277,8 @@ R.over(xLens, R.negate, {x: <span class="hljs-number">1</span>, y: <span class="
 
             <div class="description"><p>Returns a lens whose focus is the specified index.</p>
 </div>
+
+
             <div class="see">
                 See also
                 <a href="#view">view</a>,
@@ -7110,7 +7297,7 @@ R.over(headLens, R.toUpper, [<span class="hljs-string">'a'</span>, <span class="
                 <a tabindex="2" class="name" href="#lensProp">lensProp</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/lensProp.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/lensProp.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7140,6 +7327,7 @@ R.over(headLens, R.toUpper, [<span class="hljs-string">'a'</span>, <span class="
             <div class="description"><p>Returns a lens whose focus is the specified property.</p>
 </div>
 
+
             <div class="see">
                 See also
                 <a href="#view">view</a>,
@@ -7158,7 +7346,7 @@ R.over(xLens, R.negate, {x: <span class="hljs-number">1</span>, y: <span class="
                 <a tabindex="2" class="name" href="#lift">lift</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/lift.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/lift.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7197,14 +7385,12 @@ other Functor.</p>
                 <a href="#liftN">liftN</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> madd3 = R.lift(R.curry(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b, c</span>) </span>{
-  <span class="hljs-keyword">return</span> a + b + c;
-}));
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> madd3 = R.lift(R.curry((a, b, c) =&gt; a + b + c));
+
 madd3([<span class="hljs-number">1</span>,<span class="hljs-number">2</span>,<span class="hljs-number">3</span>], [<span class="hljs-number">1</span>,<span class="hljs-number">2</span>,<span class="hljs-number">3</span>], [<span class="hljs-number">1</span>]); <span class="hljs-comment">//=&gt; [3, 4, 5, 4, 5, 6, 5, 6, 7]</span>
 
-<span class="hljs-keyword">var</span> madd5 = R.lift(R.curry(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b, c, d, e</span>) </span>{
-  <span class="hljs-keyword">return</span> a + b + c + d + e;
-}));
+<span class="hljs-keyword">var</span> madd5 = R.lift(R.curry((a, b, c, d, e) =&gt; a + b + c + d + e));
+
 madd5([<span class="hljs-number">1</span>,<span class="hljs-number">2</span>], [<span class="hljs-number">3</span>], [<span class="hljs-number">4</span>, <span class="hljs-number">5</span>], [<span class="hljs-number">6</span>], [<span class="hljs-number">7</span>, <span class="hljs-number">8</span>]); <span class="hljs-comment">//=&gt; [21, 22, 22, 23, 22, 23, 23, 24]</span></code></pre>
         </section>
         <section class="card" id="liftN">
@@ -7212,7 +7398,7 @@ madd5([<span class="hljs-number">1</span>,<span class="hljs-number">2</span>], [
                 <a tabindex="2" class="name" href="#liftN">liftN</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/liftN.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/liftN.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7251,9 +7437,7 @@ lists (or other Functors).</p>
                 <a href="#lift">lift</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> madd3 = R.liftN(<span class="hljs-number">3</span>, R.curryN(<span class="hljs-number">3</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
-  <span class="hljs-keyword">return</span> R.reduce(R.add, <span class="hljs-number">0</span>, <span class="hljs-built_in">arguments</span>);
-}));
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> madd3 = R.liftN(<span class="hljs-number">3</span>, R.curryN(<span class="hljs-number">3</span>, () =&gt; R.reduce(R.add, <span class="hljs-number">0</span>, <span class="hljs-built_in">arguments</span>)));
 madd3([<span class="hljs-number">1</span>,<span class="hljs-number">2</span>,<span class="hljs-number">3</span>], [<span class="hljs-number">1</span>,<span class="hljs-number">2</span>,<span class="hljs-number">3</span>], [<span class="hljs-number">1</span>]); <span class="hljs-comment">//=&gt; [3, 4, 5, 4, 5, 6, 5, 6, 7]</span></code></pre>
         </section>
         <section class="card" id="lt">
@@ -7261,7 +7445,7 @@ madd3([<span class="hljs-number">1</span>,<span class="hljs-number">2</span>,<sp
                 <a tabindex="2" class="name" href="#lt">lt</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/lt.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/lt.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7314,7 +7498,7 @@ R.lt(<span class="hljs-string">'z'</span>, <span class="hljs-string">'a'</span>)
                 <a tabindex="2" class="name" href="#lte">lte</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/lte.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/lte.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7367,7 +7551,7 @@ R.lte(<span class="hljs-string">'z'</span>, <span class="hljs-string">'a'</span>
                 <a tabindex="2" class="name" href="#map">map</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/map.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/map.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7375,7 +7559,7 @@ R.lte(<span class="hljs-string">'z'</span>, <span class="hljs-string">'a'</span>
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-map">
                     <span class="caret rotated"></span>
-                    (a → b) → [a] → [b]
+                    Functor f =&gt; (a → b) → f a → f b
                 </button>
             </div>
 
@@ -7407,27 +7591,32 @@ supplied list.</p>
 <p>Note: <code>R.map</code> does not skip deleted or unassigned indices (sparse arrays), unlike the
 native <code>Array.prototype.map</code> method. For more details on this behavior, see:
 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#Description">https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#Description</a></p>
+<p>Dispatches to the <code>map</code> method of the second argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
 
             <div class="see">
                 See also
-                <a href="#transduce">transduce</a>.
+                <a href="#transduce
+
+Map treats also treats functions as functors and will compose them together.">transduce
+
+Map treats also treats functions as functors and will compose them together.</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> double = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{
-  <span class="hljs-keyword">return</span> x * <span class="hljs-number">2</span>;
-};
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> double = x =&gt; x * <span class="hljs-number">2</span>;
 
-R.map(double, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">//=&gt; [2, 4, 6]</span></code></pre>
+R.map(double, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">//=&gt; [2, 4, 6]</span>
+
+R.map(double, {x: <span class="hljs-number">1</span>, y: <span class="hljs-number">2</span>, z: <span class="hljs-number">3</span>}); <span class="hljs-comment">//=&gt; {x: 2, y: 4, z: 6}</span></code></pre>
         </section>
         <section class="card" id="mapAccum">
             <h2>
                 <a tabindex="2" class="name" href="#mapAccum">mapAccum</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/mapAccum.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/mapAccum.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7478,9 +7667,7 @@ a tuple <em>[acc, value]</em>.</p>
 
 
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> digits = [<span class="hljs-string">'1'</span>, <span class="hljs-string">'2'</span>, <span class="hljs-string">'3'</span>, <span class="hljs-string">'4'</span>];
-<span class="hljs-keyword">var</span> append = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{
-  <span class="hljs-keyword">return</span> [a + b, a + b];
-}
+<span class="hljs-keyword">var</span> append = (a, b) =&gt; [a + b, a + b];
 
 R.mapAccum(append, <span class="hljs-number">0</span>, digits); <span class="hljs-comment">//=&gt; ['01234', ['01', '012', '0123', '01234']]</span></code></pre>
         </section>
@@ -7489,7 +7676,7 @@ R.mapAccum(append, <span class="hljs-number">0</span>, digits); <span class="hlj
                 <a tabindex="2" class="name" href="#mapAccumRight">mapAccumRight</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/mapAccumRight.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/mapAccumRight.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7542,9 +7729,7 @@ a tuple <em>[acc, value]</em>.</p>
 
 
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> digits = [<span class="hljs-string">'1'</span>, <span class="hljs-string">'2'</span>, <span class="hljs-string">'3'</span>, <span class="hljs-string">'4'</span>];
-<span class="hljs-keyword">var</span> append = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{
-  <span class="hljs-keyword">return</span> [a + b, a + b];
-}
+<span class="hljs-keyword">var</span> append = (a, b) =&gt; [a + b, a + b];
 
 R.mapAccumRight(append, <span class="hljs-number">0</span>, digits); <span class="hljs-comment">//=&gt; ['04321', ['04321', '0432', '043', '04']]</span></code></pre>
         </section>
@@ -7553,10 +7738,13 @@ R.mapAccumRight(append, <span class="hljs-number">0</span>, digits); <span class
                 <a tabindex="2" class="name" href="#mapObj">mapObj</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/mapObj.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/mapObj.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
+            <div class="deprecated">
+                Deprecated since v0.18.0
+            </div>
 
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-mapObj">
@@ -7598,9 +7786,7 @@ generated by running each property of <code>obj</code> through <code>fn</code>. 
 
 
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> values = { x: <span class="hljs-number">1</span>, y: <span class="hljs-number">2</span>, z: <span class="hljs-number">3</span> };
-<span class="hljs-keyword">var</span> double = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">num</span>) </span>{
-  <span class="hljs-keyword">return</span> num * <span class="hljs-number">2</span>;
-};
+<span class="hljs-keyword">var</span> double = num =&gt; num * <span class="hljs-number">2</span>;
 
 R.mapObj(double, values); <span class="hljs-comment">//=&gt; { x: 2, y: 4, z: 6 }</span></code></pre>
         </section>
@@ -7609,7 +7795,7 @@ R.mapObj(double, values); <span class="hljs-comment">//=&gt; { x: 2, y: 4, z: 6 
                 <a tabindex="2" class="name" href="#mapObjIndexed">mapObjIndexed</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/mapObjIndexed.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/mapObjIndexed.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7653,9 +7839,7 @@ predicate function is passed three arguments: <em>(value, key, obj)</em>.</p>
 
 
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> values = { x: <span class="hljs-number">1</span>, y: <span class="hljs-number">2</span>, z: <span class="hljs-number">3</span> };
-<span class="hljs-keyword">var</span> prependKeyAndDouble = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">num, key, obj</span>) </span>{
-  <span class="hljs-keyword">return</span> key + (num * <span class="hljs-number">2</span>);
-};
+<span class="hljs-keyword">var</span> prependKeyAndDouble = (num, key, obj) =&gt; key + (num * <span class="hljs-number">2</span>);
 
 R.mapObjIndexed(prependKeyAndDouble, values); <span class="hljs-comment">//=&gt; { x: 'x2', y: 'y4', z: 'z6' }</span></code></pre>
         </section>
@@ -7664,7 +7848,7 @@ R.mapObjIndexed(prependKeyAndDouble, values); <span class="hljs-comment">//=&gt;
                 <a tabindex="2" class="name" href="#match">match</a>
                 <span class="pull-right">
                         <span class="label label-category">String</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/match.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/match.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7720,7 +7904,7 @@ R.match(<span class="hljs-regexp">/a/</span>, <span class="hljs-literal">null</s
                 <a tabindex="2" class="name" href="#mathMod">mathMod</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/mathMod.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/mathMod.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7784,7 +7968,7 @@ seventeenMod(<span class="hljs-number">10</span>); <span class="hljs-comment">//
                 <a tabindex="2" class="name" href="#max">max</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/max.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/max.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7834,7 +8018,7 @@ R.max(<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>
                 <a tabindex="2" class="name" href="#maxBy">maxBy</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/maxBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/maxBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7882,14 +8066,20 @@ the larger result when passed to the provided function.</p>
                 <a href="#minBy">minBy</a>.
             </div>
 
-            <pre><code class="hljs javascript">R.maxBy(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">n</span>) </span>{ <span class="hljs-keyword">return</span> n * n; }, -<span class="hljs-number">3</span>, <span class="hljs-number">2</span>); <span class="hljs-comment">//=&gt; -3</span></code></pre>
+            <pre><code class="hljs javascript"><span class="hljs-comment">//  square :: Number -&gt; Number</span>
+<span class="hljs-keyword">var</span> square = n =&gt; n * n;
+
+R.maxBy(square, -<span class="hljs-number">3</span>, <span class="hljs-number">2</span>); <span class="hljs-comment">//=&gt; -3</span>
+
+R.reduce(R.maxBy(square), <span class="hljs-number">0</span>, [<span class="hljs-number">3</span>, -<span class="hljs-number">5</span>, <span class="hljs-number">4</span>, <span class="hljs-number">1</span>, -<span class="hljs-number">2</span>]); <span class="hljs-comment">//=&gt; -5</span>
+R.reduce(R.maxBy(square), <span class="hljs-number">0</span>, []); <span class="hljs-comment">//=&gt; 0</span></code></pre>
         </section>
         <section class="card" id="mean">
             <h2>
                 <a tabindex="2" class="name" href="#mean">mean</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/mean.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/mean.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7929,7 +8119,7 @@ R.mean([]); <span class="hljs-comment">//=&gt; NaN</span></code></pre>
                 <a tabindex="2" class="name" href="#median">median</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/median.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/median.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -7970,7 +8160,7 @@ R.median([]); <span class="hljs-comment">//=&gt; NaN</span></code></pre>
                 <a tabindex="2" class="name" href="#memoize">memoize</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/memoize.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/memoize.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8008,7 +8198,7 @@ for that set of arguments will be returned.</p>
 
 
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> count = <span class="hljs-number">0</span>;
-<span class="hljs-keyword">var</span> factorial = R.memoize(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">n</span>) </span>{
+<span class="hljs-keyword">var</span> factorial = R.memoize(n =&gt; {
   count += <span class="hljs-number">1</span>;
   <span class="hljs-keyword">return</span> R.product(R.range(<span class="hljs-number">1</span>, n + <span class="hljs-number">1</span>));
 });
@@ -8022,7 +8212,7 @@ count; <span class="hljs-comment">//=&gt; 1</span></code></pre>
                 <a tabindex="2" class="name" href="#merge">merge</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/merge.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/merge.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8071,7 +8261,7 @@ resetToDefault({x: <span class="hljs-number">5</span>, y: <span class="hljs-numb
                 <a tabindex="2" class="name" href="#mergeAll">mergeAll</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/mergeAll.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/mergeAll.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8117,7 +8307,7 @@ R.mergeAll([{foo:<span class="hljs-number">1</span>},{foo:<span class="hljs-numb
                 <a tabindex="2" class="name" href="#min">min</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/min.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/min.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8167,7 +8357,7 @@ R.min(<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>
                 <a tabindex="2" class="name" href="#minBy">minBy</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/minBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/minBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8215,14 +8405,20 @@ the smaller result when passed to the provided function.</p>
                 <a href="#maxBy">maxBy</a>.
             </div>
 
-            <pre><code class="hljs javascript">R.minBy(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">n</span>) </span>{ <span class="hljs-keyword">return</span> n * n; }, -<span class="hljs-number">3</span>, <span class="hljs-number">2</span>); <span class="hljs-comment">//=&gt; 2</span></code></pre>
+            <pre><code class="hljs javascript"><span class="hljs-comment">//  square :: Number -&gt; Number</span>
+<span class="hljs-keyword">var</span> square = n =&gt; n * n;
+
+R.minBy(square, -<span class="hljs-number">3</span>, <span class="hljs-number">2</span>); <span class="hljs-comment">//=&gt; 2</span>
+
+R.reduce(R.minBy(square), <span class="hljs-literal">Infinity</span>, [<span class="hljs-number">3</span>, -<span class="hljs-number">5</span>, <span class="hljs-number">4</span>, <span class="hljs-number">1</span>, -<span class="hljs-number">2</span>]); <span class="hljs-comment">//=&gt; 1</span>
+R.reduce(R.minBy(square), <span class="hljs-literal">Infinity</span>, []); <span class="hljs-comment">//=&gt; Infinity</span></code></pre>
         </section>
         <section class="card" id="modulo">
             <h2>
                 <a tabindex="2" class="name" href="#modulo">modulo</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/modulo.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/modulo.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8258,8 +8454,8 @@ the smaller result when passed to the provided function.</p>
             </div>
 
             <div class="description"><p>Divides the second parameter by the first and returns the remainder.
-Note that this functions preserves the JavaScript-style behavior for
-modulo. For mathematical modulo see <code>mathMod</code></p>
+Note that this function preserves the JavaScript-style behavior for
+modulo. For mathematical modulo see <code>mathMod</code>.</p>
 </div>
 
 
@@ -8282,7 +8478,7 @@ isOdd(<span class="hljs-number">21</span>); <span class="hljs-comment">//=&gt; 1
                 <a tabindex="2" class="name" href="#multiply">multiply</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/multiply.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/multiply.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8337,7 +8533,7 @@ R.multiply(<span class="hljs-number">2</span>, <span class="hljs-number">5</span
                 <a tabindex="2" class="name" href="#nAry">nAry</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/nAry.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/nAry.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8378,9 +8574,9 @@ parameters. Any extraneous parameters will not be passed to the supplied functio
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> takesTwoArgs = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{
-  <span class="hljs-keyword">return</span> [a, b];
-};
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> takesTwoArgs = (a, b) =&gt; [a, b];
+
 takesTwoArgs.length; <span class="hljs-comment">//=&gt; 2</span>
 takesTwoArgs(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>); <span class="hljs-comment">//=&gt; [1, 2]</span>
 
@@ -8394,7 +8590,7 @@ takesOneArg(<span class="hljs-number">1</span>, <span class="hljs-number">2</spa
                 <a tabindex="2" class="name" href="#negate">negate</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/negate.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/negate.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8433,7 +8629,7 @@ takesOneArg(<span class="hljs-number">1</span>, <span class="hljs-number">2</spa
                 <a tabindex="2" class="name" href="#none">none</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/none.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/none.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8470,6 +8666,7 @@ takesOneArg(<span class="hljs-number">1</span>, <span class="hljs-number">2</spa
 
             <div class="description"><p>Returns <code>true</code> if no elements of the list match the predicate,
 <code>false</code> otherwise.</p>
+<p>Dispatches to the <code>any</code> method of the second argument, if present.</p>
 </div>
 
 
@@ -8487,7 +8684,7 @@ R.none(R.isNaN, [<span class="hljs-number">1</span>, <span class="hljs-number">2
                 <a tabindex="2" class="name" href="#not">not</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/not.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/not.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8536,7 +8733,7 @@ R.not(<span class="hljs-number">1</span>); =&gt; <span class="hljs-literal">fals
                 <a tabindex="2" class="name" href="#nth">nth</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/nth.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/nth.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8587,7 +8784,7 @@ R.nth(<span class="hljs-string">'abc'</span>, <span class="hljs-number">3</span>
                 <a tabindex="2" class="name" href="#nthArg">nthArg</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/nthArg.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/nthArg.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8622,108 +8819,64 @@ R.nth(<span class="hljs-string">'abc'</span>, <span class="hljs-number">3</span>
             <pre><code class="hljs javascript">R.nthArg(<span class="hljs-number">1</span>)(<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>); <span class="hljs-comment">//=&gt; 'b'</span>
 R.nthArg(-<span class="hljs-number">1</span>)(<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>); <span class="hljs-comment">//=&gt; 'c'</span></code></pre>
         </section>
-        <section class="card" id="nthChar">
+        <section class="card" id="objOf">
             <h2>
-                <a tabindex="2" class="name" href="#nthChar">nthChar</a>
+                <a tabindex="2" class="name" href="#objOf">objOf</a>
                 <span class="pull-right">
-                        <span class="label label-category">String</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/nthChar.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <span class="label label-category">Object</span>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/objOf.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
-            <div class="deprecated">
-                Deprecated since v0.16.0
-            </div>
 
             <div>
-                <button class="sig btn btn-link" data-collapser="#__details-nthChar">
+                <button class="sig btn btn-link" data-collapser="#__details-objOf">
                     <span class="caret rotated"></span>
-                    Number → String → String
+                    String → a → {String:a}
                 </button>
             </div>
 
-            <div class="details collapse panel panel-default" id="__details-nthChar">
+            <div class="details collapse panel panel-default" id="__details-objOf">
                 <ul class="list-group">
                     <li class="list-group-item">
-                        <span class="type">Number</span>
-                        <span class="name">n</span>
+                        <span class="type">String</span>
+                        <span class="name">key</span>
                         <span class="description"></span>
                     </li>
                     <li class="list-group-item">
-                        <span class="type">String</span>
-                        <span class="name">str</span>
+                        <span class="type">*</span>
+                        <span class="name">val</span>
                         <span class="description"></span>
                     </li>
                 </ul>
                 <div class="panel-body">
                     <span class="returns">Returns</span>
-                    <span class="type">String</span>
+                    <span class="type">Object</span>
                     <span class="description"></span>
                 </div>
             </div>
 
-            <div class="description"><p>Returns the nth character of the given string.</p>
+            <div class="description"><p>Creates an object containing a single key:value pair.</p>
 </div>
 
 
-
-            <pre><code class="hljs javascript">R.nthChar(<span class="hljs-number">2</span>, <span class="hljs-string">'Ramda'</span>); <span class="hljs-comment">//=&gt; 'm'</span>
-R.nthChar(-<span class="hljs-number">2</span>, <span class="hljs-string">'Ramda'</span>); <span class="hljs-comment">//=&gt; 'd'</span></code></pre>
-        </section>
-        <section class="card" id="nthCharCode">
-            <h2>
-                <a tabindex="2" class="name" href="#nthCharCode">nthCharCode</a>
-                <span class="pull-right">
-                        <span class="label label-category">String</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/nthCharCode.js"><small class="glyphicon glyphicon-new-window"></small></a>
-                </span>
-            </h2>
-
-            <div class="deprecated">
-                Deprecated since v0.16.0
+            <div class="see">
+                See also
+                <a href="#pair">pair</a>.
             </div>
 
-            <div>
-                <button class="sig btn btn-link" data-collapser="#__details-nthCharCode">
-                    <span class="caret rotated"></span>
-                    Number → String → Number
-                </button>
-            </div>
-
-            <div class="details collapse panel panel-default" id="__details-nthCharCode">
-                <ul class="list-group">
-                    <li class="list-group-item">
-                        <span class="type">Number</span>
-                        <span class="name">n</span>
-                        <span class="description"></span>
-                    </li>
-                    <li class="list-group-item">
-                        <span class="type">String</span>
-                        <span class="name">str</span>
-                        <span class="description"></span>
-                    </li>
-                </ul>
-                <div class="panel-body">
-                    <span class="returns">Returns</span>
-                    <span class="type">Number</span>
-                    <span class="description"></span>
-                </div>
-            </div>
-
-            <div class="description"><p>Returns the character code of the nth character of the given string.</p>
-</div>
-
-
-
-            <pre><code class="hljs javascript">R.nthCharCode(<span class="hljs-number">2</span>, <span class="hljs-string">'Ramda'</span>); <span class="hljs-comment">//=&gt; 'm'.charCodeAt(0)</span>
-R.nthCharCode(-<span class="hljs-number">2</span>, <span class="hljs-string">'Ramda'</span>); <span class="hljs-comment">//=&gt; 'd'.charCodeAt(0)</span></code></pre>
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> matchPhrases = R.compose(
+  R.objOf(<span class="hljs-string">'must'</span>),
+  R.map(R.objOf(<span class="hljs-string">'match_phrase'</span>))
+);
+matchPhrases([<span class="hljs-string">'foo'</span>, <span class="hljs-string">'bar'</span>, <span class="hljs-string">'baz'</span>]); <span class="hljs-comment">//=&gt; {must: [{match_phrase: 'foo'}, {match_phrase: 'bar'}, {match_phrase: 'baz'}]}</span></code></pre>
         </section>
         <section class="card" id="of">
             <h2>
                 <a tabindex="2" class="name" href="#of">of</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/of.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/of.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8767,7 +8920,7 @@ R.of([<span class="hljs-number">42</span>]); <span class="hljs-comment">//=&gt; 
                 <a tabindex="2" class="name" href="#omit">omit</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/omit.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/omit.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8818,7 +8971,7 @@ R.of([<span class="hljs-number">42</span>]); <span class="hljs-comment">//=&gt; 
                 <a tabindex="2" class="name" href="#once">once</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/once.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/once.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8849,11 +9002,12 @@ R.of([<span class="hljs-number">42</span>]); <span class="hljs-comment">//=&gt; 
 
             <div class="description"><p>Accepts a function <code>fn</code> and returns a function that guards invocation of <code>fn</code> such that
 <code>fn</code> can only ever be called once, no matter how many times the returned function is
-invoked.</p>
+invoked. The first value calculated is returned in subsequent invocations.</p>
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> addOneOnce = R.once(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>)</span>{ <span class="hljs-keyword">return</span> x + <span class="hljs-number">1</span>; });
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> addOneOnce = R.once(x =&gt; x + <span class="hljs-number">1</span>);
 addOneOnce(<span class="hljs-number">10</span>); <span class="hljs-comment">//=&gt; 11</span>
 addOneOnce(addOneOnce(<span class="hljs-number">50</span>)); <span class="hljs-comment">//=&gt; 11</span></code></pre>
         </section>
@@ -8862,7 +9016,7 @@ addOneOnce(addOneOnce(<span class="hljs-number">50</span>)); <span class="hljs-c
                 <a tabindex="2" class="name" href="#or">or</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/or.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/or.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8877,30 +9031,28 @@ addOneOnce(addOneOnce(<span class="hljs-number">50</span>)); <span class="hljs-c
             <div class="details collapse panel panel-default" id="__details-or">
                 <ul class="list-group">
                     <li class="list-group-item">
-                        <span class="type">*</span>
+                        <span class="type">Boolean</span>
                         <span class="name">a</span>
-                        <span class="description"><p>any value</p>
+                        <span class="description"><p>A boolean value</p>
 </span>
                     </li>
                     <li class="list-group-item">
-                        <span class="type">*</span>
+                        <span class="type">Boolean</span>
                         <span class="name">b</span>
-                        <span class="description"><p>any other value</p>
+                        <span class="description"><p>A boolean value</p>
 </span>
                     </li>
                 </ul>
                 <div class="panel-body">
                     <span class="returns">Returns</span>
-                    <span class="type">*</span>
-                    <span class="description"><p>the first truthy argument, otherwise the last argument.</p>
+                    <span class="type">Boolean</span>
+                    <span class="description"><p><code>true</code> if one or both arguments are <code>true</code>, <code>false</code> otherwise</p>
 </span>
                 </div>
             </div>
 
-            <div class="description"><p>A function that returns the first truthy of two arguments otherwise the
-last argument. Note that this is NOT short-circuited, meaning that if
-expressions are passed they are both evaluated.</p>
-<p>Dispatches to the <code>or</code> method of the first argument if applicable.</p>
+            <div class="description"><p>Returns <code>true</code> if one or both of its arguments are <code>true</code>. Returns <code>false</code>
+if both arguments are <code>false</code>.</p>
 </div>
 
 
@@ -8909,16 +9061,17 @@ expressions are passed they are both evaluated.</p>
                 <a href="#either">either</a>.
             </div>
 
-            <pre><code class="hljs javascript">R.or(<span class="hljs-literal">false</span>, <span class="hljs-literal">true</span>); <span class="hljs-comment">//=&gt; true</span>
-R.or(<span class="hljs-number">0</span>, []); <span class="hljs-comment">//=&gt; []</span>
-R.or(<span class="hljs-literal">null</span>, <span class="hljs-string">''</span>); =&gt; <span class="hljs-string">''</span></code></pre>
+            <pre><code class="hljs javascript">R.or(<span class="hljs-literal">true</span>, <span class="hljs-literal">true</span>); <span class="hljs-comment">//=&gt; true</span>
+R.or(<span class="hljs-literal">true</span>, <span class="hljs-literal">false</span>); <span class="hljs-comment">//=&gt; true</span>
+R.or(<span class="hljs-literal">false</span>, <span class="hljs-literal">true</span>); <span class="hljs-comment">//=&gt; true</span>
+R.or(<span class="hljs-literal">false</span>, <span class="hljs-literal">false</span>); <span class="hljs-comment">//=&gt; false</span></code></pre>
         </section>
         <section class="card" id="over">
             <h2>
                 <a tabindex="2" class="name" href="#over">over</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/over.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/over.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8956,8 +9109,10 @@ R.or(<span class="hljs-literal">null</span>, <span class="hljs-string">''</span>
             </div>
 
             <div class="description"><p>Returns the result of &quot;setting&quot; the portion of the given data structure
-focused by the given lens to the given value.</p>
+focused by the given lens to the result of applying the given function to
+the focused value.</p>
 </div>
+
 
             <div class="see">
                 See also
@@ -8970,12 +9125,61 @@ focused by the given lens to the given value.</p>
 
 R.over(headLens, R.toUpper, [<span class="hljs-string">'foo'</span>, <span class="hljs-string">'bar'</span>, <span class="hljs-string">'baz'</span>]); <span class="hljs-comment">//=&gt; ['FOO', 'bar', 'baz']</span></code></pre>
         </section>
+        <section class="card" id="pair">
+            <h2>
+                <a tabindex="2" class="name" href="#pair">pair</a>
+                <span class="pull-right">
+                        <span class="label label-category">List</span>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/pair.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                </span>
+            </h2>
+
+
+            <div>
+                <button class="sig btn btn-link" data-collapser="#__details-pair">
+                    <span class="caret rotated"></span>
+                    a → b → (a,b)
+                </button>
+            </div>
+
+            <div class="details collapse panel panel-default" id="__details-pair">
+                <ul class="list-group">
+                    <li class="list-group-item">
+                        <span class="type">*</span>
+                        <span class="name">fst</span>
+                        <span class="description"></span>
+                    </li>
+                    <li class="list-group-item">
+                        <span class="type">*</span>
+                        <span class="name">snd</span>
+                        <span class="description"></span>
+                    </li>
+                </ul>
+                <div class="panel-body">
+                    <span class="returns">Returns</span>
+                    <span class="type">Array</span>
+                    <span class="description"></span>
+                </div>
+            </div>
+
+            <div class="description"><p>Takes two arguments, <code>fst</code> and <code>snd</code>, and returns <code>[fst, snd]</code>.</p>
+</div>
+
+
+            <div class="see">
+                See also
+                <a href="#createMapEntry">createMapEntry</a>,
+                <a href="#of">of</a>.
+            </div>
+
+            <pre><code class="hljs javascript">pair(<span class="hljs-string">'foo'</span>, <span class="hljs-string">'bar'</span>); <span class="hljs-comment">//=&gt; ['foo', 'bar']</span></code></pre>
+        </section>
         <section class="card" id="partial">
             <h2>
                 <a tabindex="2" class="name" href="#partial">partial</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/partial.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/partial.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -8983,7 +9187,7 @@ R.over(headLens, R.toUpper, [<span class="hljs-string">'foo'</span>, <span class
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-partial">
                     <span class="caret rotated"></span>
-                    (a → b → … → i → j → … → m → n) → a → b→ … → i → (j → … → m → n)
+                    ((a, b, c, …, n) → x) → [a, b, c, …] → ((d, e, f, …, n) → x)
                 </button>
             </div>
 
@@ -8991,41 +9195,42 @@ R.over(headLens, R.toUpper, [<span class="hljs-string">'foo'</span>, <span class
                 <ul class="list-group">
                     <li class="list-group-item">
                         <span class="type">function</span>
-                        <span class="name">fn</span>
-                        <span class="description"><p>The function to invoke.</p>
-</span>
+                        <span class="name">f</span>
+                        <span class="description"></span>
                     </li>
                     <li class="list-group-item">
-                        <span class="type">*</span>
+                        <span class="type">Array</span>
                         <span class="name">args</span>
-                        <span class="description"><p>Arguments to prepend to <code>fn</code> when the returned function is invoked.</p>
-</span>
+                        <span class="description"></span>
                     </li>
                 </ul>
                 <div class="panel-body">
                     <span class="returns">Returns</span>
                     <span class="type">function</span>
-                    <span class="description"><p>A new function wrapping <code>fn</code>. When invoked, it will call <code>fn</code>
-        with <code>args</code> prepended to <code>fn</code>&#39;s arguments list.</p>
-</span>
+                    <span class="description"></span>
                 </div>
             </div>
 
-            <div class="description"><p>Accepts as its arguments a function and any number of values and returns a function that,
-when invoked, calls the original function with all of the values prepended to the
-original function&#39;s arguments list. In some libraries this function is named <code>applyLeft</code>.</p>
+            <div class="description"><p>Takes a function <code>f</code> and a list of arguments, and returns a function <code>g</code>.
+When applied, <code>g</code> returns the result of applying <code>f</code> to the arguments
+provided initially followed by the arguments provided to <code>g</code>.</p>
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> multiply = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{ <span class="hljs-keyword">return</span> a * b; };
-<span class="hljs-keyword">var</span> double = R.partial(multiply, <span class="hljs-number">2</span>);
+            <div class="see">
+                See also
+                <a href="#partialRight">partialRight</a>.
+            </div>
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> multiply = (a, b) =&gt; a * b;
+<span class="hljs-keyword">var</span> double = R.partial(multiply, [<span class="hljs-number">2</span>]);
 double(<span class="hljs-number">2</span>); <span class="hljs-comment">//=&gt; 4</span>
 
-<span class="hljs-keyword">var</span> greet = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">salutation, title, firstName, lastName</span>) </span>{
-  <span class="hljs-keyword">return</span> salutation + <span class="hljs-string">', '</span> + title + <span class="hljs-string">' '</span> + firstName + <span class="hljs-string">' '</span> + lastName + <span class="hljs-string">'!'</span>;
-};
-<span class="hljs-keyword">var</span> sayHello = R.partial(greet, <span class="hljs-string">'Hello'</span>);
-<span class="hljs-keyword">var</span> sayHelloToMs = R.partial(sayHello, <span class="hljs-string">'Ms.'</span>);
+<span class="hljs-keyword">var</span> greet = (salutation, title, firstName, lastName) =&gt;
+  salutation + <span class="hljs-string">', '</span> + title + <span class="hljs-string">' '</span> + firstName + <span class="hljs-string">' '</span> + lastName + <span class="hljs-string">'!'</span>;
+
+<span class="hljs-keyword">var</span> sayHello = R.partial(greet, [<span class="hljs-string">'Hello'</span>]);
+<span class="hljs-keyword">var</span> sayHelloToMs = R.partial(sayHello, [<span class="hljs-string">'Ms.'</span>]);
 sayHelloToMs(<span class="hljs-string">'Jane'</span>, <span class="hljs-string">'Jones'</span>); <span class="hljs-comment">//=&gt; 'Hello, Ms. Jane Jones!'</span></code></pre>
         </section>
         <section class="card" id="partialRight">
@@ -9033,7 +9238,7 @@ sayHelloToMs(<span class="hljs-string">'Jane'</span>, <span class="hljs-string">
                 <a tabindex="2" class="name" href="#partialRight">partialRight</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/partialRight.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/partialRight.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9041,7 +9246,7 @@ sayHelloToMs(<span class="hljs-string">'Jane'</span>, <span class="hljs-string">
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-partialRight">
                     <span class="caret rotated"></span>
-                    (a → b→ … → i → j → … → m → n) → j → … → m → n → (a → b→ … → i)
+                    ((a, b, c, …, n) → x) → [d, e, f, …, n] → ((a, b, c, …) → x)
                 </button>
             </div>
 
@@ -9049,38 +9254,37 @@ sayHelloToMs(<span class="hljs-string">'Jane'</span>, <span class="hljs-string">
                 <ul class="list-group">
                     <li class="list-group-item">
                         <span class="type">function</span>
-                        <span class="name">fn</span>
-                        <span class="description"><p>The function to invoke.</p>
-</span>
+                        <span class="name">f</span>
+                        <span class="description"></span>
                     </li>
                     <li class="list-group-item">
-                        <span class="type">*</span>
+                        <span class="type">Array</span>
                         <span class="name">args</span>
-                        <span class="description"><p>Arguments to append to <code>fn</code> when the returned function is invoked.</p>
-</span>
+                        <span class="description"></span>
                     </li>
                 </ul>
                 <div class="panel-body">
                     <span class="returns">Returns</span>
                     <span class="type">function</span>
-                    <span class="description"><p>A new function wrapping <code>fn</code>. When invoked, it will call <code>fn</code> with
-        <code>args</code> appended to <code>fn</code>&#39;s arguments list.</p>
-</span>
+                    <span class="description"></span>
                 </div>
             </div>
 
-            <div class="description"><p>Accepts as its arguments a function and any number of values and returns a function that,
-when invoked, calls the original function with all of the values appended to the original
-function&#39;s arguments list.</p>
-<p>Note that <code>partialRight</code> is the opposite of <code>partial</code>: <code>partialRight</code> fills <code>fn</code>&#39;s arguments
-from the right to the left.  In some libraries this function is named <code>applyRight</code>.</p>
+            <div class="description"><p>Takes a function <code>f</code> and a list of arguments, and returns a function <code>g</code>.
+When applied, <code>g</code> returns the result of applying <code>f</code> to the arguments
+provided to <code>g</code> followed by the arguments provided initially.</p>
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> greet = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">salutation, title, firstName, lastName</span>) </span>{
-  <span class="hljs-keyword">return</span> salutation + <span class="hljs-string">', '</span> + title + <span class="hljs-string">' '</span> + firstName + <span class="hljs-string">' '</span> + lastName + <span class="hljs-string">'!'</span>;
-};
-<span class="hljs-keyword">var</span> greetMsJaneJones = R.partialRight(greet, <span class="hljs-string">'Ms.'</span>, <span class="hljs-string">'Jane'</span>, <span class="hljs-string">'Jones'</span>);
+            <div class="see">
+                See also
+                <a href="#partial">partial</a>.
+            </div>
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> greet = (salutation, title, firstName, lastName) =&gt;
+  salutation + <span class="hljs-string">', '</span> + title + <span class="hljs-string">' '</span> + firstName + <span class="hljs-string">' '</span> + lastName + <span class="hljs-string">'!'</span>;
+
+<span class="hljs-keyword">var</span> greetMsJaneJones = R.partialRight(greet, [<span class="hljs-string">'Ms.'</span>, <span class="hljs-string">'Jane'</span>, <span class="hljs-string">'Jones'</span>]);
 
 greetMsJaneJones(<span class="hljs-string">'Hello'</span>); <span class="hljs-comment">//=&gt; 'Hello, Ms. Jane Jones!'</span></code></pre>
         </section>
@@ -9089,7 +9293,7 @@ greetMsJaneJones(<span class="hljs-string">'Hello'</span>); <span class="hljs-co
                 <a tabindex="2" class="name" href="#partition">partition</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/partition.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/partition.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9139,7 +9343,7 @@ elements which do and do not satisfy the predicate, respectively.</p>
                 <a tabindex="2" class="name" href="#path">path</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/path.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/path.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9181,7 +9385,7 @@ R.path([<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</spa
                 <a tabindex="2" class="name" href="#pathEq">pathEq</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/pathEq.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/pathEq.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9236,12 +9440,61 @@ in <code>R.equals</code> terms. Most likely used to filter a list.</p>
 <span class="hljs-keyword">var</span> isFamous = R.pathEq([<span class="hljs-string">'address'</span>, <span class="hljs-string">'zipCode'</span>], <span class="hljs-number">90210</span>);
 R.filter(isFamous, users); <span class="hljs-comment">//=&gt; [ user1 ]</span></code></pre>
         </section>
+        <section class="card" id="pathOr">
+            <h2>
+                <a tabindex="2" class="name" href="#pathOr">pathOr</a>
+                <span class="pull-right">
+                        <span class="label label-category">Object</span>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/pathOr.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                </span>
+            </h2>
+
+
+            <div>
+                <button class="sig btn btn-link" data-collapser="#__details-pathOr">
+                    <span class="caret rotated"></span>
+                    a → [String] → Object → a
+                </button>
+            </div>
+
+            <div class="details collapse panel panel-default" id="__details-pathOr">
+                <ul class="list-group">
+                    <li class="list-group-item">
+                        <span class="type">*</span>
+                        <span class="name">d</span>
+                        <span class="description"><p>The default value.</p>
+</span>
+                    </li>
+                    <li class="list-group-item">
+                        <span class="type">Array</span>
+                        <span class="name">p</span>
+                        <span class="description"><p>The path to use.</p>
+</span>
+                    </li>
+                </ul>
+                <div class="panel-body">
+                    <span class="returns">Returns</span>
+                    <span class="type">*</span>
+                    <span class="description"><p>The data at <code>path</code> of the supplied object or the default value.</p>
+</span>
+                </div>
+            </div>
+
+            <div class="description"><p>If the given, non-null object has a value at the given path, returns
+the value at that path. Otherwise returns the provided default value.</p>
+</div>
+
+
+
+            <pre><code class="hljs javascript">R.pathOr(<span class="hljs-string">'N/A'</span>, [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>], {a: {b: <span class="hljs-number">2</span>}}); <span class="hljs-comment">//=&gt; 2</span>
+R.pathOr(<span class="hljs-string">'N/A'</span>, [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>], {c: {b: <span class="hljs-number">2</span>}}); <span class="hljs-comment">//=&gt; "N/A"</span></code></pre>
+        </section>
         <section class="card" id="pick">
             <h2>
                 <a tabindex="2" class="name" href="#pick">pick</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/pick.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/pick.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9283,7 +9536,8 @@ property is ignored.</p>
 
             <div class="see">
                 See also
-                <a href="#omit">omit</a>.
+                <a href="#omit">omit</a>,
+                <a href="#props">props</a>.
             </div>
 
             <pre><code class="hljs javascript">R.pick([<span class="hljs-string">'a'</span>, <span class="hljs-string">'d'</span>], {a: <span class="hljs-number">1</span>, b: <span class="hljs-number">2</span>, c: <span class="hljs-number">3</span>, d: <span class="hljs-number">4</span>}); <span class="hljs-comment">//=&gt; {a: 1, d: 4}</span>
@@ -9294,7 +9548,7 @@ R.pick([<span class="hljs-string">'a'</span>, <span class="hljs-string">'e'</spa
                 <a tabindex="2" class="name" href="#pickAll">pickAll</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/pickAll.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/pickAll.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9346,7 +9600,7 @@ R.pickAll([<span class="hljs-string">'a'</span>, <span class="hljs-string">'e'</
                 <a tabindex="2" class="name" href="#pickBy">pickBy</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/pickBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/pickBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9393,7 +9647,7 @@ satisfy the supplied predicate.</p>
                 <a href="#pick">pick</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isUpperCase = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">val, key</span>) </span>{ <span class="hljs-keyword">return</span> key.toUpperCase() === key; }
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isUpperCase = (val, key) =&gt; key.toUpperCase() === key;
 R.pickBy(isUpperCase, {a: <span class="hljs-number">1</span>, b: <span class="hljs-number">2</span>, A: <span class="hljs-number">3</span>, B: <span class="hljs-number">4</span>}); <span class="hljs-comment">//=&gt; {A: 3, B: 4}</span></code></pre>
         </section>
         <section class="card" id="pipe">
@@ -9401,7 +9655,7 @@ R.pickBy(isUpperCase, {a: <span class="hljs-number">1</span>, b: <span class="hl
                 <a tabindex="2" class="name" href="#pipe">pipe</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/pipe.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/pipe.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9409,7 +9663,7 @@ R.pickBy(isUpperCase, {a: <span class="hljs-number">1</span>, b: <span class="hl
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-pipe">
                     <span class="caret rotated"></span>
-                    (((a, b, …, n) → o), (o → p), …, (x → y), (y → z)) → (a → b → … → n → z)
+                    (((a, b, …, n) → o), (o → p), …, (x → y), (y → z)) → ((a, b, …, n) → z)
                 </button>
             </div>
 
@@ -9448,7 +9702,7 @@ f(<span class="hljs-number">3</span>, <span class="hljs-number">4</span>); <span
                 <a tabindex="2" class="name" href="#pipeK">pipeK</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/pipeK.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/pipeK.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9508,7 +9762,7 @@ getStateCode(Maybe.of(<span class="hljs-string">'[Invalid JSON]'</span>));
                 <a tabindex="2" class="name" href="#pipeP">pipeP</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/pipeP.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/pipeP.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9554,7 +9808,7 @@ functions must be unary.</p>
                 <a tabindex="2" class="name" href="#pluck">pluck</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/pluck.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/pluck.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9593,6 +9847,10 @@ functions must be unary.</p>
 </div>
 
 
+            <div class="see">
+                See also
+                <a href="#props">props</a>.
+            </div>
 
             <pre><code class="hljs javascript">R.pluck(<span class="hljs-string">'a'</span>)([{a: <span class="hljs-number">1</span>}, {a: <span class="hljs-number">2</span>}]); <span class="hljs-comment">//=&gt; [1, 2]</span>
 R.pluck(<span class="hljs-number">0</span>)([[<span class="hljs-number">1</span>, <span class="hljs-number">2</span>], [<span class="hljs-number">3</span>, <span class="hljs-number">4</span>]]);   <span class="hljs-comment">//=&gt; [1, 3]</span></code></pre>
@@ -9602,7 +9860,7 @@ R.pluck(<span class="hljs-number">0</span>)([[<span class="hljs-number">1</span>
                 <a tabindex="2" class="name" href="#prepend">prepend</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/prepend.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/prepend.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9654,7 +9912,7 @@ list.</p>
                 <a tabindex="2" class="name" href="#product">product</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/product.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/product.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9699,7 +9957,7 @@ list.</p>
                 <a tabindex="2" class="name" href="#project">project</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/project.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/project.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9749,7 +10007,7 @@ R.project([<span class="hljs-string">'name'</span>, <span class="hljs-string">'g
                 <a tabindex="2" class="name" href="#prop">prop</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/prop.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/prop.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9797,7 +10055,7 @@ R.prop(<span class="hljs-string">'x'</span>, {}); <span class="hljs-comment">//=
                 <a tabindex="2" class="name" href="#propEq">propEq</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/propEq.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/propEq.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9858,7 +10116,7 @@ R.filter(hasBrownHair, kids); <span class="hljs-comment">//=&gt; [fred, rusty]</
                 <a tabindex="2" class="name" href="#propIs">propIs</a>
                 <span class="pull-right">
                         <span class="label label-category">Type</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/propIs.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/propIs.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9915,7 +10173,7 @@ R.propIs(<span class="hljs-built_in">Number</span>, <span class="hljs-string">'x
                 <a tabindex="2" class="name" href="#propOr">propOr</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/propOr.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/propOr.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -9978,7 +10236,7 @@ favoriteWithDefault(alice);  <span class="hljs-comment">//=&gt; 'Ramda'</span></
                 <a tabindex="2" class="name" href="#props">props</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/props.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/props.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10029,7 +10287,7 @@ fullName({last: <span class="hljs-string">'Bullet-Tooth'</span>, age: <span clas
                 <a tabindex="2" class="name" href="#propSatisfies">propSatisfies</a>
                 <span class="pull-right">
                         <span class="label label-category">Logic</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/propSatisfies.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/propSatisfies.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10084,7 +10342,7 @@ predicate; <code>false</code> otherwise.</p>
                 <a tabindex="2" class="name" href="#range">range</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/range.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/range.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10133,7 +10391,7 @@ R.range(<span class="hljs-number">50</span>, <span class="hljs-number">53</span>
                 <a tabindex="2" class="name" href="#reduce">reduce</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/reduce.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/reduce.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10188,13 +10446,16 @@ the native <code>Array.prototype.reduce</code> method. For more details on this 
 
             <div class="see">
                 See also
-                <a href="#reduced">reduced</a>.
+                <a href="#reduced
+
+Dispatches to the &#x60;reduce&#x60; method of the third argument">reduced
+
+Dispatches to the &#x60;reduce&#x60; method of the third argument</a>,
+                <a href="#if present.">if present.</a>.
             </div>
 
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> numbers = [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>];
-<span class="hljs-keyword">var</span> add = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{
-  <span class="hljs-keyword">return</span> a + b;
-};
+<span class="hljs-keyword">var</span> add = (a, b) =&gt; a + b;
 
 R.reduce(add, <span class="hljs-number">10</span>, numbers); <span class="hljs-comment">//=&gt; 16</span></code></pre>
         </section>
@@ -10203,7 +10464,7 @@ R.reduce(add, <span class="hljs-number">10</span>, numbers); <span class="hljs-c
                 <a tabindex="2" class="name" href="#reduced">reduced</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/reduced.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/reduced.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10249,7 +10510,7 @@ reduceRight, or reduceRightIndexed.</p>
             </div>
 
             <pre><code class="hljs javascript">R.reduce(
-  R.pipe(R.add, R.ifElse(R.lte(<span class="hljs-number">10</span>), R.reduced, R.identity)),
+  R.pipe(R.add, R.when(R.gte(R.__, <span class="hljs-number">10</span>), R.reduced)),
   <span class="hljs-number">0</span>,
   [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>]) <span class="hljs-comment">// 10</span></code></pre>
         </section>
@@ -10258,7 +10519,7 @@ reduceRight, or reduceRightIndexed.</p>
                 <a tabindex="2" class="name" href="#reduceRight">reduceRight</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/reduceRight.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/reduceRight.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10313,9 +10574,7 @@ the native <code>Array.prototype.reduce</code> method. For more details on this 
 
 
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> pairs = [ [<span class="hljs-string">'a'</span>, <span class="hljs-number">1</span>], [<span class="hljs-string">'b'</span>, <span class="hljs-number">2</span>], [<span class="hljs-string">'c'</span>, <span class="hljs-number">3</span>] ];
-<span class="hljs-keyword">var</span> flattenPairs = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">acc, pair</span>) </span>{
-  <span class="hljs-keyword">return</span> acc.concat(pair);
-};
+<span class="hljs-keyword">var</span> flattenPairs = (acc, pair) =&gt; acc.concat(pair);
 
 R.reduceRight(flattenPairs, [], pairs); <span class="hljs-comment">//=&gt; [ 'c', 3, 'b', 2, 'a', 1 ]</span></code></pre>
         </section>
@@ -10324,7 +10583,7 @@ R.reduceRight(flattenPairs, [], pairs); <span class="hljs-comment">//=&gt; [ 'c'
                 <a tabindex="2" class="name" href="#reject">reject</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/reject.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/reject.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10371,9 +10630,8 @@ function returns falsy. The predicate function is passed one argument: <em>(valu
                 <a href="#filter">filter</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isOdd = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">n</span>) </span>{
-  <span class="hljs-keyword">return</span> n % <span class="hljs-number">2</span> === <span class="hljs-number">1</span>;
-};
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isOdd = (n) =&gt; n % <span class="hljs-number">2</span> === <span class="hljs-number">1</span>;
+
 R.reject(isOdd, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]); <span class="hljs-comment">//=&gt; [2, 4]</span></code></pre>
         </section>
         <section class="card" id="remove">
@@ -10381,7 +10639,7 @@ R.reject(isOdd, [<span class="hljs-number">1</span>, <span class="hljs-number">2
                 <a tabindex="2" class="name" href="#remove">remove</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/remove.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/remove.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10437,7 +10695,7 @@ copy of the list with the changes.
                 <a tabindex="2" class="name" href="#repeat">repeat</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/repeat.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/repeat.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10488,7 +10746,7 @@ repeatedObjs[<span class="hljs-number">0</span>] === repeatedObjs[<span class="h
                 <a tabindex="2" class="name" href="#replace">replace</a>
                 <span class="pull-right">
                         <span class="label label-category">String</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/replace.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/replace.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10545,7 +10803,7 @@ R.replace(<span class="hljs-regexp">/foo/g</span>, <span class="hljs-string">'ba
                 <a tabindex="2" class="name" href="#reverse">reverse</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/reverse.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/reverse.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10562,20 +10820,18 @@ R.replace(<span class="hljs-regexp">/foo/g</span>, <span class="hljs-string">'ba
                     <li class="list-group-item">
                         <span class="type">Array</span>
                         <span class="name">list</span>
-                        <span class="description"><p>The list to reverse.</p>
-</span>
+                        <span class="description"></span>
                     </li>
                 </ul>
                 <div class="panel-body">
                     <span class="returns">Returns</span>
                     <span class="type">Array</span>
-                    <span class="description"><p>A copy of the list in reverse order.</p>
-</span>
+                    <span class="description"></span>
                 </div>
             </div>
 
-            <div class="description"><p>Returns a new list with the same elements as the original list, just
-in the reverse order.</p>
+            <div class="description"><p>Returns a new list or string with the elements or characters in reverse
+order.</p>
 </div>
 
 
@@ -10583,14 +10839,19 @@ in the reverse order.</p>
             <pre><code class="hljs javascript">R.reverse([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]);  <span class="hljs-comment">//=&gt; [3, 2, 1]</span>
 R.reverse([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>]);     <span class="hljs-comment">//=&gt; [2, 1]</span>
 R.reverse([<span class="hljs-number">1</span>]);        <span class="hljs-comment">//=&gt; [1]</span>
-R.reverse([]);         <span class="hljs-comment">//=&gt; []</span></code></pre>
+R.reverse([]);         <span class="hljs-comment">//=&gt; []</span>
+
+R.reverse(<span class="hljs-string">'abc'</span>);      <span class="hljs-comment">//=&gt; 'cba'</span>
+R.reverse(<span class="hljs-string">'ab'</span>);       <span class="hljs-comment">//=&gt; 'ba'</span>
+R.reverse(<span class="hljs-string">'a'</span>);        <span class="hljs-comment">//=&gt; 'a'</span>
+R.reverse(<span class="hljs-string">''</span>);         <span class="hljs-comment">//=&gt; ''</span></code></pre>
         </section>
         <section class="card" id="scan">
             <h2>
                 <a tabindex="2" class="name" href="#scan">scan</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/scan.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/scan.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10645,7 +10906,7 @@ R.reverse([]);         <span class="hljs-comment">//=&gt; []</span></code></pre>
                 <a tabindex="2" class="name" href="#set">set</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/set.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/set.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10686,6 +10947,7 @@ R.reverse([]);         <span class="hljs-comment">//=&gt; []</span></code></pre>
 focused by the given lens to the given value.</p>
 </div>
 
+
             <div class="see">
                 See also
                 <a href="#prop">prop</a>,
@@ -10703,7 +10965,7 @@ R.set(xLens, <span class="hljs-number">8</span>, {x: <span class="hljs-number">1
                 <a tabindex="2" class="name" href="#slice">slice</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/slice.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/slice.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10744,6 +11006,7 @@ R.set(xLens, <span class="hljs-number">8</span>, {x: <span class="hljs-number">1
 
             <div class="description"><p>Returns the elements of the given list or string (or object with a <code>slice</code>
 method) from <code>fromIndex</code> (inclusive) to <code>toIndex</code> (exclusive).</p>
+<p>Dispatches to the <code>slice</code> method of the third argument, if present.</p>
 </div>
 
 
@@ -10759,7 +11022,7 @@ R.slice(<span class="hljs-number">0</span>, <span class="hljs-number">3</span>, 
                 <a tabindex="2" class="name" href="#sort">sort</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/sort.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/sort.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10800,6 +11063,7 @@ if they are equal.  Please note that this is a <strong>copy</strong> of the list
 </div>
 
 
+
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> diff = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{ <span class="hljs-keyword">return</span> a - b; };
 R.sort(diff, [<span class="hljs-number">4</span>,<span class="hljs-number">2</span>,<span class="hljs-number">7</span>,<span class="hljs-number">5</span>]); <span class="hljs-comment">//=&gt; [2, 4, 5, 7]</span></code></pre>
         </section>
@@ -10808,7 +11072,7 @@ R.sort(diff, [<span class="hljs-number">4</span>,<span class="hljs-number">2</sp
                 <a tabindex="2" class="name" href="#sortBy">sortBy</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/sortBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/sortBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10847,7 +11111,7 @@ R.sort(diff, [<span class="hljs-number">4</span>,<span class="hljs-number">2</sp
 
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> sortByFirstItem = R.sortBy(prop(<span class="hljs-number">0</span>));
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> sortByFirstItem = R.sortBy(R.prop(<span class="hljs-number">0</span>));
 <span class="hljs-keyword">var</span> sortByNameCaseInsensitive = R.sortBy(R.compose(R.toLower, R.prop(<span class="hljs-string">'name'</span>)));
 <span class="hljs-keyword">var</span> pairs = [[-<span class="hljs-number">1</span>, <span class="hljs-number">1</span>], [-<span class="hljs-number">2</span>, <span class="hljs-number">2</span>], [-<span class="hljs-number">3</span>, <span class="hljs-number">3</span>]];
 sortByFirstItem(pairs); <span class="hljs-comment">//=&gt; [[-3, 3], [-2, 2], [-1, 1]]</span>
@@ -10871,7 +11135,7 @@ sortByNameCaseInsensitive(people); <span class="hljs-comment">//=&gt; [alice, bo
                 <a tabindex="2" class="name" href="#split">split</a>
                 <span class="pull-right">
                         <span class="label label-category">String</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/split.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/split.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10879,7 +11143,7 @@ sortByNameCaseInsensitive(people); <span class="hljs-comment">//=&gt; [alice, bo
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-split">
                     <span class="caret rotated"></span>
-                    String → String → [String]
+                    (String | RegExp) → String → [String]
                 </button>
             </div>
 
@@ -10888,7 +11152,7 @@ sortByNameCaseInsensitive(people); <span class="hljs-comment">//=&gt; [alice, bo
                     <li class="list-group-item">
                         <span class="type">String</span>
                         <span class="name">sep</span>
-                        <span class="description"><p>The separator string.</p>
+                        <span class="description"><p>The pattern.</p>
 </span>
                     </li>
                     <li class="list-group-item">
@@ -10926,7 +11190,7 @@ R.split(<span class="hljs-string">'.'</span>, <span class="hljs-string">'a.b.c.x
                 <a tabindex="2" class="name" href="#splitEvery">splitEvery</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/splitEvery.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/splitEvery.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -10971,7 +11235,7 @@ R.splitEvery(<span class="hljs-number">3</span>, <span class="hljs-string">'foob
                 <a tabindex="2" class="name" href="#subtract">subtract</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/subtract.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/subtract.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11029,7 +11293,7 @@ complementaryAngle(<span class="hljs-number">72</span>); <span class="hljs-comme
                 <a tabindex="2" class="name" href="#sum">sum</a>
                 <span class="pull-right">
                         <span class="label label-category">Math</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/sum.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/sum.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11074,7 +11338,7 @@ complementaryAngle(<span class="hljs-number">72</span>); <span class="hljs-comme
                 <a tabindex="2" class="name" href="#T">T</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/T.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/T.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11082,18 +11346,22 @@ complementaryAngle(<span class="hljs-number">72</span>); <span class="hljs-comme
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-T">
                     <span class="caret rotated"></span>
-                    * → true
+                    * → Boolean
                 </button>
             </div>
 
             <div class="details collapse panel panel-default" id="__details-T">
                 <ul class="list-group">
+                    <li class="list-group-item">
+                        <span class="type">*</span>
+                        <span class="name"></span>
+                        <span class="description"></span>
+                    </li>
                 </ul>
                 <div class="panel-body">
                     <span class="returns">Returns</span>
                     <span class="type">Boolean</span>
-                    <span class="description"><p><code>true</code>.</p>
-</span>
+                    <span class="description"></span>
                 </div>
             </div>
 
@@ -11114,7 +11382,7 @@ complementaryAngle(<span class="hljs-number">72</span>); <span class="hljs-comme
                 <a tabindex="2" class="name" href="#tail">tail</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/tail.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/tail.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11143,6 +11411,7 @@ complementaryAngle(<span class="hljs-number">72</span>); <span class="hljs-comme
 
             <div class="description"><p>Returns all but the first element of the given list or string (or object
 with a <code>tail</code> method).</p>
+<p>Dispatches to the <code>slice</code> method of the first argument, if present.</p>
 </div>
 
 
@@ -11168,7 +11437,7 @@ R.tail(<span class="hljs-string">''</span>);     <span class="hljs-comment">//=&
                 <a tabindex="2" class="name" href="#take">take</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/take.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/take.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11202,6 +11471,7 @@ R.tail(<span class="hljs-string">''</span>);     <span class="hljs-comment">//=&
 
             <div class="description"><p>Returns the first <code>n</code> elements of the given list, string, or
 transducer/transformer (or object with a <code>take</code> method).</p>
+<p>Dispatches to the <code>take</code> method of the second argument, if present.</p>
 </div>
 
 
@@ -11236,7 +11506,7 @@ takeFive(personnel);
                 <a tabindex="2" class="name" href="#takeLast">takeLast</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/takeLast.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/takeLast.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11281,7 +11551,7 @@ If <code>n &gt; list.length</code>, returns a list of <code>list.length</code> e
             </div>
 
             <pre><code class="hljs javascript">R.takeLast(<span class="hljs-number">1</span>, [<span class="hljs-string">'foo'</span>, <span class="hljs-string">'bar'</span>, <span class="hljs-string">'baz'</span>]); <span class="hljs-comment">//=&gt; ['baz']</span>
-R.takeLast(<span class="hljs-number">2</span>, [<span class="hljs-string">'foo'</span>, <span class="hljs-string">'bar'</span>, <span class="hljs-string">'baz'</span>]); <span class="hljs-comment">//=&gt; ['for', 'baz']</span>
+R.takeLast(<span class="hljs-number">2</span>, [<span class="hljs-string">'foo'</span>, <span class="hljs-string">'bar'</span>, <span class="hljs-string">'baz'</span>]); <span class="hljs-comment">//=&gt; ['bar', 'baz']</span>
 R.takeLast(<span class="hljs-number">3</span>, [<span class="hljs-string">'foo'</span>, <span class="hljs-string">'bar'</span>, <span class="hljs-string">'baz'</span>]); <span class="hljs-comment">//=&gt; ['foo', 'bar', 'baz']</span>
 R.takeLast(<span class="hljs-number">4</span>, [<span class="hljs-string">'foo'</span>, <span class="hljs-string">'bar'</span>, <span class="hljs-string">'baz'</span>]); <span class="hljs-comment">//=&gt; ['foo', 'bar', 'baz']</span>
 R.takeLast(<span class="hljs-number">3</span>, <span class="hljs-string">'ramda'</span>);               <span class="hljs-comment">//=&gt; 'mda'</span></code></pre>
@@ -11291,7 +11561,7 @@ R.takeLast(<span class="hljs-number">3</span>, <span class="hljs-string">'ramda'
                 <a tabindex="2" class="name" href="#takeLastWhile">takeLastWhile</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/takeLastWhile.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/takeLastWhile.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11338,9 +11608,7 @@ function is passed one argument: <em>(value)</em>.</p>
                 <a href="#dropLastWhile">dropLastWhile</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isNotOne = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{
-  <span class="hljs-keyword">return</span> !(x === <span class="hljs-number">1</span>);
-};
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isNotOne = x =&gt; x !== <span class="hljs-number">1</span>;
 
 R.takeLastWhile(isNotOne, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]); <span class="hljs-comment">//=&gt; [2, 3, 4]</span></code></pre>
         </section>
@@ -11349,7 +11617,7 @@ R.takeLastWhile(isNotOne, [<span class="hljs-number">1</span>, <span class="hljs
                 <a tabindex="2" class="name" href="#takeWhile">takeWhile</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/takeWhile.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/takeWhile.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11388,6 +11656,7 @@ R.takeLastWhile(isNotOne, [<span class="hljs-number">1</span>, <span class="hljs
 to the supplied predicate function, and terminating when the predicate function returns
 <code>false</code>. Excludes the element that caused the predicate function to fail. The predicate
 function is passed one argument: <em>(value)</em>.</p>
+<p>Dispatches to the <code>takeWhile</code> method of the second argument, if present.</p>
 <p>Acts as a transducer if a transformer is given in list position.</p>
 </div>
 
@@ -11398,9 +11667,7 @@ function is passed one argument: <em>(value)</em>.</p>
                 <a href="#dropWhile">dropWhile</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isNotFour = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{
-  <span class="hljs-keyword">return</span> !(x === <span class="hljs-number">4</span>);
-};
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> isNotFour = x =&gt; x !== <span class="hljs-number">4</span>;
 
 R.takeWhile(isNotFour, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]); <span class="hljs-comment">//=&gt; [1, 2, 3]</span></code></pre>
         </section>
@@ -11409,7 +11676,7 @@ R.takeWhile(isNotFour, [<span class="hljs-number">1</span>, <span class="hljs-nu
                 <a tabindex="2" class="name" href="#tap">tap</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/tap.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/tap.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11447,7 +11714,8 @@ R.takeWhile(isNotFour, [<span class="hljs-number">1</span>, <span class="hljs-nu
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> sayX = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{ <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'x is '</span> + x); };
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> sayX = x =&gt; <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'x is '</span> + x);
 R.tap(sayX, <span class="hljs-number">100</span>); <span class="hljs-comment">//=&gt; 100</span>
 <span class="hljs-comment">//-&gt; 'x is 100'</span></code></pre>
         </section>
@@ -11456,7 +11724,7 @@ R.tap(sayX, <span class="hljs-number">100</span>); <span class="hljs-comment">//
                 <a tabindex="2" class="name" href="#test">test</a>
                 <span class="pull-right">
                         <span class="label label-category">String</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/test.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/test.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11505,7 +11773,7 @@ R.test(<span class="hljs-regexp">/^y/</span>, <span class="hljs-string">'xyz'</s
                 <a tabindex="2" class="name" href="#times">times</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/times.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/times.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11555,7 +11823,7 @@ gradually incremented to <code>n - 1</code>.</p>
                 <a tabindex="2" class="name" href="#toLower">toLower</a>
                 <span class="pull-right">
                         <span class="label label-category">String</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/toLower.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/toLower.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11600,7 +11868,7 @@ gradually incremented to <code>n - 1</code>.</p>
                 <a tabindex="2" class="name" href="#toPairs">toPairs</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/toPairs.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/toPairs.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11648,7 +11916,7 @@ consistent across different JS platforms.</p>
                 <a tabindex="2" class="name" href="#toPairsIn">toPairsIn</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/toPairsIn.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/toPairsIn.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11685,6 +11953,7 @@ consistent across different JS platforms.</p>
 </div>
 
 
+
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> F = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{ <span class="hljs-keyword">this</span>.x = <span class="hljs-string">'X'</span>; };
 F.prototype.y = <span class="hljs-string">'Y'</span>;
 <span class="hljs-keyword">var</span> f = <span class="hljs-keyword">new</span> F();
@@ -11695,7 +11964,7 @@ R.toPairsIn(f); <span class="hljs-comment">//=&gt; [['x','X'], ['y','Y']]</span>
                 <a tabindex="2" class="name" href="#toString">toString</a>
                 <span class="pull-right">
                         <span class="label label-category">String</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/toString.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/toString.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11754,7 +12023,7 @@ R.toString(<span class="hljs-keyword">new</span> <span class="hljs-built_in">Dat
                 <a tabindex="2" class="name" href="#toUpper">toUpper</a>
                 <span class="pull-right">
                         <span class="label label-category">String</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/toUpper.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/toUpper.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11799,7 +12068,7 @@ R.toString(<span class="hljs-keyword">new</span> <span class="hljs-built_in">Dat
                 <a tabindex="2" class="name" href="#transduce">transduce</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/transduce.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/transduce.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11884,7 +12153,7 @@ R.transduce(transducer, R.flip(R.append), [], numbers); <span class="hljs-commen
                 <a tabindex="2" class="name" href="#trim">trim</a>
                 <span class="pull-right">
                         <span class="label label-category">String</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/trim.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/trim.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11926,7 +12195,7 @@ R.map(R.trim, R.split(<span class="hljs-string">','</span>, <span class="hljs-st
                 <a tabindex="2" class="name" href="#type">type</a>
                 <span class="pull-right">
                         <span class="label label-category">Type</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/type.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/type.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -11974,7 +12243,7 @@ R.type(<span class="hljs-regexp">/[A-z]/</span>); <span class="hljs-comment">//=
                 <a tabindex="2" class="name" href="#unapply">unapply</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/unapply.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/unapply.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12025,7 +12294,7 @@ which takes an array. R.unapply is the inverse of R.apply.</p>
                 <a tabindex="2" class="name" href="#unary">unary</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/unary.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/unary.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12060,6 +12329,7 @@ parameter. Any extraneous parameters will not be passed to the supplied function
 </div>
 
 
+
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> takesTwoArgs = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{
   <span class="hljs-keyword">return</span> [a, b];
 };
@@ -12076,7 +12346,7 @@ takesOneArg(<span class="hljs-number">1</span>, <span class="hljs-number">2</spa
                 <a tabindex="2" class="name" href="#uncurryN">uncurryN</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/uncurryN.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/uncurryN.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12120,25 +12390,17 @@ takesOneArg(<span class="hljs-number">1</span>, <span class="hljs-number">2</spa
                 <a href="#curry">curry</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> addFour = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a</span>) </span>{
-  <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">b</span>) </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">c</span>) </span>{
-      <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">d</span>) </span>{
-        <span class="hljs-keyword">return</span> a + b + c + d;
-      };
-    };
-  };
-};
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> addFour = a =&gt; b =&gt; c =&gt; d =&gt; a + b + c + d;
 
 <span class="hljs-keyword">var</span> uncurriedAddFour = R.uncurryN(<span class="hljs-number">4</span>, addFour);
-curriedAddFour(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>); <span class="hljs-comment">//=&gt; 10</span></code></pre>
+uncurriedAddFour(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>); <span class="hljs-comment">//=&gt; 10</span></code></pre>
         </section>
         <section class="card" id="unfold">
             <h2>
                 <a tabindex="2" class="name" href="#unfold">unfold</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/unfold.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/unfold.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12183,7 +12445,8 @@ list and the seed to be used in the next call to the iterator function.</p>
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> f = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">n</span>) </span>{ <span class="hljs-keyword">return</span> n &gt; <span class="hljs-number">50</span> ? <span class="hljs-literal">false</span> : [-n, n + <span class="hljs-number">10</span>] };
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> f = n =&gt; n &gt; <span class="hljs-number">50</span> ? <span class="hljs-literal">false</span> : [-n, n + <span class="hljs-number">10</span>];
 R.unfold(f, <span class="hljs-number">10</span>); <span class="hljs-comment">//=&gt; [-10, -20, -30, -40, -50]</span></code></pre>
         </section>
         <section class="card" id="union">
@@ -12191,7 +12454,7 @@ R.unfold(f, <span class="hljs-number">10</span>); <span class="hljs-comment">//=
                 <a tabindex="2" class="name" href="#union">union</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/union.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/union.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12240,7 +12503,7 @@ elements of each list.</p>
                 <a tabindex="2" class="name" href="#unionWith">unionWith</a>
                 <span class="pull-right">
                         <span class="label label-category">Relation</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/unionWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/unionWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12292,17 +12555,16 @@ determined according to the value returned by applying the supplied predicate to
                 <a href="#union">union</a>.
             </div>
 
-            <pre><code class="hljs javascript"><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">cmp</span>(<span class="hljs-params">x, y</span>) </span>{ <span class="hljs-keyword">return</span> x.a === y.a; }
-<span class="hljs-keyword">var</span> l1 = [{a: <span class="hljs-number">1</span>}, {a: <span class="hljs-number">2</span>}];
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> l1 = [{a: <span class="hljs-number">1</span>}, {a: <span class="hljs-number">2</span>}];
 <span class="hljs-keyword">var</span> l2 = [{a: <span class="hljs-number">1</span>}, {a: <span class="hljs-number">4</span>}];
-R.unionWith(cmp, l1, l2); <span class="hljs-comment">//=&gt; [{a: 1}, {a: 2}, {a: 4}]</span></code></pre>
+R.unionWith(R.eqBy(R.prop(<span class="hljs-string">'a'</span>)), l1, l2); <span class="hljs-comment">//=&gt; [{a: 1}, {a: 2}, {a: 4}]</span></code></pre>
         </section>
         <section class="card" id="uniq">
             <h2>
                 <a tabindex="2" class="name" href="#uniq">uniq</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/uniq.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/uniq.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12346,7 +12608,7 @@ R.uniq([[<span class="hljs-number">42</span>], [<span class="hljs-number">42</sp
                 <a tabindex="2" class="name" href="#uniqBy">uniqBy</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/uniqBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/uniqBy.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12397,7 +12659,7 @@ comparison.</p>
                 <a tabindex="2" class="name" href="#uniqWith">uniqWith</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/uniqWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/uniqWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12438,18 +12700,85 @@ the first item if two items compare equal based on the predicate.</p>
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> strEq = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{ <span class="hljs-keyword">return</span> <span class="hljs-built_in">String</span>(a) === <span class="hljs-built_in">String</span>(b); };
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> strEq = R.eqBy(<span class="hljs-built_in">String</span>);
 R.uniqWith(strEq)([<span class="hljs-number">1</span>, <span class="hljs-string">'1'</span>, <span class="hljs-number">2</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">//=&gt; [1, 2]</span>
 R.uniqWith(strEq)([{}, {}]);       <span class="hljs-comment">//=&gt; [{}]</span>
 R.uniqWith(strEq)([<span class="hljs-number">1</span>, <span class="hljs-string">'1'</span>, <span class="hljs-number">1</span>]);    <span class="hljs-comment">//=&gt; [1]</span>
 R.uniqWith(strEq)([<span class="hljs-string">'1'</span>, <span class="hljs-number">1</span>, <span class="hljs-number">1</span>]);    <span class="hljs-comment">//=&gt; ['1']</span></code></pre>
+        </section>
+        <section class="card" id="unless">
+            <h2>
+                <a tabindex="2" class="name" href="#unless">unless</a>
+                <span class="pull-right">
+                        <span class="label label-category">Logic</span>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/unless.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                </span>
+            </h2>
+
+
+            <div>
+                <button class="sig btn btn-link" data-collapser="#__details-unless">
+                    <span class="caret rotated"></span>
+                    (a → Boolean) → (a → a) → a → a
+                </button>
+            </div>
+
+            <div class="details collapse panel panel-default" id="__details-unless">
+                <ul class="list-group">
+                    <li class="list-group-item">
+                        <span class="type">function</span>
+                        <span class="name">pred</span>
+                        <span class="description"><p>A predicate function</p>
+</span>
+                    </li>
+                    <li class="list-group-item">
+                        <span class="type">function</span>
+                        <span class="name">whenFalseFn</span>
+                        <span class="description"><p>A function to invoke when the <code>pred</code> evaluates
+                              to a falsy value.</p>
+</span>
+                    </li>
+                    <li class="list-group-item">
+                        <span class="type">*</span>
+                        <span class="name">x</span>
+                        <span class="description"><p>An object to test with the <code>pred</code> function and
+                              pass to <code>whenFalseFn</code> if necessary.</p>
+</span>
+                    </li>
+                </ul>
+                <div class="panel-body">
+                    <span class="returns">Returns</span>
+                    <span class="type">*</span>
+                    <span class="description"><p>Either <code>x</code> or the result of applying <code>x</code> to <code>whenFalseFn</code>.</p>
+</span>
+                </div>
+            </div>
+
+            <div class="description"><p>Tests the final argument by passing it to the given predicate function.
+If the predicate is not satisfied, the function will return the
+result of calling the <code>whenFalseFn</code> function with the same argument. If the
+predicate is satisfied, the argument is returned as is.</p>
+</div>
+
+
+            <div class="see">
+                See also
+                <a href="#ifElse">ifElse</a>,
+                <a href="#when">when</a>.
+            </div>
+
+            <pre><code class="hljs javascript"><span class="hljs-comment">// coerceArray :: (a|[a]) -&gt; [a]</span>
+<span class="hljs-keyword">var</span> coerceArray = R.unless(R.isArrayLike, R.of);
+coerceArray([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">//=&gt; [1, 2, 3]</span>
+coerceArray(<span class="hljs-number">1</span>);         <span class="hljs-comment">//=&gt; [1]</span></code></pre>
         </section>
         <section class="card" id="unnest">
             <h2>
                 <a tabindex="2" class="name" href="#unnest">unnest</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/unnest.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/unnest.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12457,35 +12786,34 @@ R.uniqWith(strEq)([<span class="hljs-string">'1'</span>, <span class="hljs-numbe
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-unnest">
                     <span class="caret rotated"></span>
-                    [a] → [b]
+                    Chain c =&gt; c (c a) → c a
                 </button>
             </div>
 
             <div class="details collapse panel panel-default" id="__details-unnest">
                 <ul class="list-group">
                     <li class="list-group-item">
-                        <span class="type">Array</span>
+                        <span class="type">*</span>
                         <span class="name">list</span>
-                        <span class="description"><p>The array to consider.</p>
-</span>
+                        <span class="description"></span>
                     </li>
                 </ul>
                 <div class="panel-body">
                     <span class="returns">Returns</span>
-                    <span class="type">Array</span>
-                    <span class="description"><p>The flattened list.</p>
-</span>
+                    <span class="type">*</span>
+                    <span class="description"></span>
                 </div>
             </div>
 
-            <div class="description"><p>Returns a new list by pulling every item at the first level of nesting out, and putting
-them in a new array.</p>
+            <div class="description"><p>Shorthand for <code>R.chain(R.identity)</code>, which removes one level of nesting
+from any <a href="https://github.com/fantasyland/fantasy-land#chain">Chain</a>.</p>
 </div>
 
 
             <div class="see">
                 See also
-                <a href="#flatten">flatten</a>.
+                <a href="#flatten">flatten</a>,
+                <a href="#chain">chain</a>.
             </div>
 
             <pre><code class="hljs javascript">R.unnest([<span class="hljs-number">1</span>, [<span class="hljs-number">2</span>], [[<span class="hljs-number">3</span>]]]); <span class="hljs-comment">//=&gt; [1, 2, [3]]</span>
@@ -12496,7 +12824,7 @@ R.unnest([[<span class="hljs-number">1</span>, <span class="hljs-number">2</span
                 <a tabindex="2" class="name" href="#update">update</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/update.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/update.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12555,7 +12883,7 @@ R.update(<span class="hljs-number">1</span>)(<span class="hljs-number">11</span>
                 <a tabindex="2" class="name" href="#useWith">useWith</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/useWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/useWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12563,7 +12891,7 @@ R.update(<span class="hljs-number">1</span>)(<span class="hljs-number">11</span>
             <div>
                 <button class="sig btn btn-link" data-collapser="#__details-useWith">
                     <span class="caret rotated"></span>
-                    (x1 → x2 → … → z) → ((a → x1), (b → x2), …) → (a → b → … → z)
+                    (x1 → x2 → … → z) → [(a → x1), (b → x2), …] → (a → b → … → z)
                 </button>
             </div>
 
@@ -12576,9 +12904,9 @@ R.update(<span class="hljs-number">1</span>)(<span class="hljs-number">11</span>
 </span>
                     </li>
                     <li class="list-group-item">
-                        <span class="type">function</span>
+                        <span class="type">Array</span>
                         <span class="name">transformers</span>
-                        <span class="description"><p>A variable number of transformer functions</p>
+                        <span class="description"><p>A list of transformer functions</p>
 </span>
                     </li>
                 </ul>
@@ -12590,7 +12918,7 @@ R.update(<span class="hljs-number">1</span>)(<span class="hljs-number">11</span>
                 </div>
             </div>
 
-            <div class="description"><p>Accepts a function <code>fn</code> and any number of transformer functions and returns a new
+            <div class="description"><p>Accepts a function <code>fn</code> and a list of transformer functions and returns a new curried
 function. When the new function is invoked, it calls the function <code>fn</code> with parameters
 consisting of the result of calling each supplied handler on successive arguments to the
 new function.</p>
@@ -12601,38 +12929,18 @@ pass an identity function so that the new function reports the correct arity.</p
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> double = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">y</span>) </span>{ <span class="hljs-keyword">return</span> y * <span class="hljs-number">2</span>; };
-<span class="hljs-keyword">var</span> square = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x</span>) </span>{ <span class="hljs-keyword">return</span> x * x; };
-<span class="hljs-keyword">var</span> add = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{ <span class="hljs-keyword">return</span> a + b; };
-<span class="hljs-comment">// Adds any number of arguments together</span>
-<span class="hljs-keyword">var</span> addAll = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
-  <span class="hljs-keyword">return</span> R.reduce(add, <span class="hljs-number">0</span>, <span class="hljs-built_in">arguments</span>);
-};
 
-<span class="hljs-comment">// Basic example</span>
-<span class="hljs-keyword">var</span> addDoubleAndSquare = R.useWith(addAll, double, square);
-
-<span class="hljs-comment">//≅ addAll(double(10), square(5));</span>
-addDoubleAndSquare(<span class="hljs-number">10</span>, <span class="hljs-number">5</span>); <span class="hljs-comment">//=&gt; 45</span>
-
-<span class="hljs-comment">// Example of passing more arguments than transformers</span>
-<span class="hljs-comment">//≅ addAll(double(10), square(5), 100);</span>
-addDoubleAndSquare(<span class="hljs-number">10</span>, <span class="hljs-number">5</span>, <span class="hljs-number">100</span>); <span class="hljs-comment">//=&gt; 145</span>
-
-<span class="hljs-comment">// If there are extra _expected_ arguments that don't need to be transformed, although</span>
-<span class="hljs-comment">// you can ignore them, it might be best to pass in the identity function so that the new</span>
-<span class="hljs-comment">// function correctly reports arity.</span>
-<span class="hljs-keyword">var</span> addDoubleAndSquareWithExtraParams = R.useWith(addAll, double, square, R.identity);
-<span class="hljs-comment">// addDoubleAndSquareWithExtraParams.length //=&gt; 3</span>
-<span class="hljs-comment">//≅ addAll(double(10), square(5), R.identity(100));</span>
-addDoubleAndSquare(<span class="hljs-number">10</span>, <span class="hljs-number">5</span>, <span class="hljs-number">100</span>); <span class="hljs-comment">//=&gt; 145</span></code></pre>
+            <pre><code class="hljs javascript">R.useWith(<span class="hljs-built_in">Math</span>.pow, [R.identity, R.identity])(<span class="hljs-number">3</span>, <span class="hljs-number">4</span>); <span class="hljs-comment">//=&gt; 81</span>
+R.useWith(<span class="hljs-built_in">Math</span>.pow, [R.identity, R.identity])(<span class="hljs-number">3</span>)(<span class="hljs-number">4</span>); <span class="hljs-comment">//=&gt; 81</span>
+R.useWith(<span class="hljs-built_in">Math</span>.pow, [R.dec, R.inc])(<span class="hljs-number">3</span>, <span class="hljs-number">4</span>); <span class="hljs-comment">//=&gt; 32</span>
+R.useWith(<span class="hljs-built_in">Math</span>.pow, [R.dec, R.inc])(<span class="hljs-number">3</span>)(<span class="hljs-number">4</span>); <span class="hljs-comment">//=&gt; 32</span></code></pre>
         </section>
         <section class="card" id="values">
             <h2>
                 <a tabindex="2" class="name" href="#values">values</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/values.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/values.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12675,7 +12983,7 @@ different JS platforms.</p>
                 <a tabindex="2" class="name" href="#valuesIn">valuesIn</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/valuesIn.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/valuesIn.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12711,6 +13019,7 @@ consistent across different JS platforms.</p>
 </div>
 
 
+
             <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> F = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{ <span class="hljs-keyword">this</span>.x = <span class="hljs-string">'X'</span>; };
 F.prototype.y = <span class="hljs-string">'Y'</span>;
 <span class="hljs-keyword">var</span> f = <span class="hljs-keyword">new</span> F();
@@ -12721,7 +13030,7 @@ R.valuesIn(f); <span class="hljs-comment">//=&gt; ['X', 'Y']</span></code></pre>
                 <a tabindex="2" class="name" href="#view">view</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/view.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/view.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12757,6 +13066,7 @@ R.valuesIn(f); <span class="hljs-comment">//=&gt; ['X', 'Y']</span></code></pre>
 The lens&#39;s focus determines which portion of the data structure is visible.</p>
 </div>
 
+
             <div class="see">
                 See also
                 <a href="#prop">prop</a>,
@@ -12769,12 +13079,81 @@ The lens&#39;s focus determines which portion of the data structure is visible.<
 R.view(xLens, {x: <span class="hljs-number">1</span>, y: <span class="hljs-number">2</span>});  <span class="hljs-comment">//=&gt; 1</span>
 R.view(xLens, {x: <span class="hljs-number">4</span>, y: <span class="hljs-number">2</span>});  <span class="hljs-comment">//=&gt; 4</span></code></pre>
         </section>
+        <section class="card" id="when">
+            <h2>
+                <a tabindex="2" class="name" href="#when">when</a>
+                <span class="pull-right">
+                        <span class="label label-category">Logic</span>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/when.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                </span>
+            </h2>
+
+
+            <div>
+                <button class="sig btn btn-link" data-collapser="#__details-when">
+                    <span class="caret rotated"></span>
+                    (a → Boolean) → (a → a) → a → a
+                </button>
+            </div>
+
+            <div class="details collapse panel panel-default" id="__details-when">
+                <ul class="list-group">
+                    <li class="list-group-item">
+                        <span class="type">function</span>
+                        <span class="name">pred</span>
+                        <span class="description"><p>A predicate function</p>
+</span>
+                    </li>
+                    <li class="list-group-item">
+                        <span class="type">function</span>
+                        <span class="name">whenTrueFn</span>
+                        <span class="description"><p>A function to invoke when the <code>condition</code>
+                             evaluates to a truthy value.</p>
+</span>
+                    </li>
+                    <li class="list-group-item">
+                        <span class="type">*</span>
+                        <span class="name">x</span>
+                        <span class="description"><p>An object to test with the <code>pred</code> function and
+                             pass to <code>whenTrueFn</code> if necessary.</p>
+</span>
+                    </li>
+                </ul>
+                <div class="panel-body">
+                    <span class="returns">Returns</span>
+                    <span class="type">*</span>
+                    <span class="description"><p>Either <code>x</code> or the result of applying <code>x</code> to <code>whenTrueFn</code>.</p>
+</span>
+                </div>
+            </div>
+
+            <div class="description"><p>Tests the final argument by passing it to the given predicate function.
+If the predicate is satisfied, the function will return the result
+of calling the <code>whenTrueFn</code> function with the same argument. If the predicate
+is not satisfied, the argument is returned as is.</p>
+</div>
+
+
+            <div class="see">
+                See also
+                <a href="#ifElse">ifElse</a>,
+                <a href="#unless">unless</a>.
+            </div>
+
+            <pre><code class="hljs javascript"><span class="hljs-comment">// truncate :: String -&gt; String</span>
+<span class="hljs-keyword">var</span> truncate = R.when(
+  R.propSatisfies(R.gt(R.__, <span class="hljs-number">10</span>), <span class="hljs-string">'length'</span>),
+  R.pipe(R.take(<span class="hljs-number">10</span>), R.append(<span class="hljs-string">'…'</span>), R.join(<span class="hljs-string">''</span>))
+);
+truncate(<span class="hljs-string">'12345'</span>);         <span class="hljs-comment">//=&gt; '12345'</span>
+truncate(<span class="hljs-string">'0123456789ABC'</span>); <span class="hljs-comment">//=&gt; '0123456789…'</span></code></pre>
+        </section>
         <section class="card" id="where">
             <h2>
                 <a tabindex="2" class="name" href="#where">where</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/where.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/where.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12836,7 +13215,7 @@ pred({a: <span class="hljs-string">'foo'</span>, b: <span class="hljs-string">'x
                 <a tabindex="2" class="name" href="#whereEq">whereEq</a>
                 <span class="pull-right">
                         <span class="label label-category">Object</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/whereEq.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/whereEq.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12894,7 +13273,7 @@ pred({a: <span class="hljs-number">1</span>, b: <span class="hljs-number">1</spa
                 <a tabindex="2" class="name" href="#wrap">wrap</a>
                 <span class="pull-right">
                         <span class="label label-category">Function</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/wrap.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/wrap.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -12935,11 +13314,10 @@ other processing either before the internal function is called or with its resul
 
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> greet = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">name</span>) </span>{<span class="hljs-keyword">return</span> <span class="hljs-string">'Hello '</span> + name;};
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> greet = name =&gt; <span class="hljs-string">'Hello '</span> + name;
 
-<span class="hljs-keyword">var</span> shoutedGreet = R.wrap(greet, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">gr, name</span>) </span>{
-  <span class="hljs-keyword">return</span> gr(name).toUpperCase();
-});
+<span class="hljs-keyword">var</span> shoutedGreet = R.wrap(greet, (gr, name) =&gt; gr(name).toUpperCase());
+
 shoutedGreet(<span class="hljs-string">"Kathy"</span>); <span class="hljs-comment">//=&gt; "HELLO KATHY"</span>
 
 <span class="hljs-keyword">var</span> shortenedGreet = R.wrap(greet, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">gr, name</span>) </span>{
@@ -12952,7 +13330,7 @@ shortenedGreet(<span class="hljs-string">"Robert"</span>); <span class="hljs-com
                 <a tabindex="2" class="name" href="#xprod">xprod</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/xprod.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/xprod.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -13001,7 +13379,7 @@ pair from the lists.</p>
                 <a tabindex="2" class="name" href="#zip">zip</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/zip.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/zip.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -13051,7 +13429,7 @@ Note: <code>zip</code> is equivalent to <code>zipWith(function(a, b) { return [a
                 <a tabindex="2" class="name" href="#zipObj">zipObj</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/zipObj.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/zipObj.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -13098,7 +13476,7 @@ Note: <code>zip</code> is equivalent to <code>zipWith(function(a, b) { return [a
                 <a tabindex="2" class="name" href="#zipWith">zipWith</a>
                 <span class="pull-right">
                         <span class="label label-category">List</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.17.1/src/zipWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v0.18.0/src/zipWith.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 
@@ -13146,18 +13524,14 @@ truncated to the length of the shorter of the two input lists.</p>
 </div>
 
 
-            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> f = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">x, y</span>) </span>{
+
+            <pre><code class="hljs javascript"><span class="hljs-keyword">var</span> f = (x, y) =&gt; {
   <span class="hljs-comment">// ...</span>
 };
 R.zipWith(f, [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>], [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>]);
 <span class="hljs-comment">//=&gt; [f(1, 'a'), f(2, 'b'), f(3, 'c')]</span></code></pre>
         </section>
     </main>
-    <script>
-        var DOC_DATA = [{"name":"__","category":"Function"},{"name":"add","category":"Math"},{"name":"addIndex","category":"Function"},{"name":"adjust","category":"List"},{"name":"all","category":"List"},{"name":"allPass","category":"Logic"},{"name":"always","category":"Function"},{"name":"and","category":"Logic"},{"name":"any","category":"List"},{"name":"anyPass","category":"Logic"},{"name":"ap","category":"Function"},{"name":"aperture","category":"List"},{"name":"append","category":"List"},{"name":"apply","category":"Function"},{"name":"assoc","category":"Object"},{"name":"assocPath","category":"Object"},{"name":"binary","category":"Function"},{"name":"bind","category":"Function"},{"name":"both","category":"Logic"},{"name":"call","category":"Function"},{"name":"chain","category":"List"},{"name":"clone","category":"Object"},{"name":"commute","category":"List"},{"name":"commuteMap","category":"List"},{"name":"comparator","category":"Function"},{"name":"complement","category":"Logic"},{"name":"compose","category":"Function"},{"name":"composeK","category":"Function"},{"name":"composeP","category":"Function"},{"name":"concat","category":"List"},{"name":"cond","category":"Logic"},{"name":"construct","category":"Function"},{"name":"constructN","category":"Function"},{"name":"contains","category":"List"},{"name":"containsWith","category":"List"},{"name":"converge","category":"Function"},{"name":"countBy","category":"Relation"},{"name":"createMapEntry","category":"Object"},{"name":"curry","category":"Function"},{"name":"curryN","category":"Function"},{"name":"dec","category":"Math"},{"name":"defaultTo","category":"Logic"},{"name":"difference","category":"Relation"},{"name":"differenceWith","category":"Relation"},{"name":"dissoc","category":"Object"},{"name":"dissocPath","category":"Object"},{"name":"divide","category":"Math"},{"name":"drop","category":"List"},{"name":"dropLast","category":"List"},{"name":"dropLastWhile","category":"List"},{"name":"dropRepeats","category":"List"},{"name":"dropRepeatsWith","category":"List"},{"name":"dropWhile","category":"List"},{"name":"either","category":"Logic"},{"name":"empty","category":"Function"},{"name":"eqProps","category":"Object"},{"name":"equals","category":"Relation"},{"name":"evolve","category":"Object"},{"name":"F","category":"Function"},{"name":"filter","category":"List"},{"name":"find","category":"List"},{"name":"findIndex","category":"List"},{"name":"findLast","category":"List"},{"name":"findLastIndex","category":"List"},{"name":"flatten","category":"List"},{"name":"flip","category":"Function"},{"name":"forEach","category":"List"},{"name":"fromPairs","category":"List"},{"name":"functions","category":"Object"},{"name":"functionsIn","category":"Object"},{"name":"groupBy","category":"List"},{"name":"gt","category":"Relation"},{"name":"gte","category":"Relation"},{"name":"has","category":"Object"},{"name":"hasIn","category":"Object"},{"name":"head","category":"List"},{"name":"identical","category":"Relation"},{"name":"identity","category":"Function"},{"name":"ifElse","category":"Logic"},{"name":"inc","category":"Math"},{"name":"indexOf","category":"List"},{"name":"init","category":"List"},{"name":"insert","category":"List"},{"name":"insertAll","category":"List"},{"name":"intersection","category":"Relation"},{"name":"intersectionWith","category":"Relation"},{"name":"intersperse","category":"List"},{"name":"into","category":"List"},{"name":"invert","category":"Object"},{"name":"invertObj","category":"Object"},{"name":"invoker","category":"Function"},{"name":"is","category":"Type"},{"name":"isArrayLike","category":"Type"},{"name":"isEmpty","category":"Logic"},{"name":"isNil","category":"Type"},{"name":"isSet","category":"List"},{"name":"join","category":"List"},{"name":"keys","category":"Object"},{"name":"keysIn","category":"Object"},{"name":"last","category":"List"},{"name":"lastIndexOf","category":"List"},{"name":"length","category":"List"},{"name":"lens","category":"Object"},{"name":"lensIndex","category":"Object"},{"name":"lensProp","category":"Object"},{"name":"lift","category":"
-Function"},{"name":"liftN","category":"Function"},{"name":"lt","category":"Relation"},{"name":"lte","category":"Relation"},{"name":"map","category":"List"},{"name":"mapAccum","category":"List"},{"name":"mapAccumRight","category":"List"},{"name":"mapObj","category":"Object"},{"name":"mapObjIndexed","category":"Object"},{"name":"match","category":"String"},{"name":"mathMod","category":"Math"},{"name":"max","category":"Relation"},{"name":"maxBy","category":"Relation"},{"name":"mean","category":"Math"},{"name":"median","category":"Math"},{"name":"memoize","category":"Function"},{"name":"merge","category":"Object"},{"name":"mergeAll","category":"List"},{"name":"min","category":"Relation"},{"name":"minBy","category":"Relation"},{"name":"modulo","category":"Math"},{"name":"multiply","category":"Math"},{"name":"nAry","category":"Function"},{"name":"negate","category":"Math"},{"name":"none","category":"List"},{"name":"not","category":"Logic"},{"name":"nth","category":"List"},{"name":"nthArg","category":"Function"},{"name":"nthChar","category":"String"},{"name":"nthCharCode","category":"String"},{"name":"of","category":"Function"},{"name":"omit","category":"Object"},{"name":"once","category":"Function"},{"name":"or","category":"Logic"},{"name":"over","category":"Object"},{"name":"partial","category":"Function"},{"name":"partialRight","category":"Function"},{"name":"partition","category":"List"},{"name":"path","category":"Object"},{"name":"pathEq","category":"Relation"},{"name":"pick","category":"Object"},{"name":"pickAll","category":"Object"},{"name":"pickBy","category":"Object"},{"name":"pipe","category":"Function"},{"name":"pipeK","category":"Function"},{"name":"pipeP","category":"Function"},{"name":"pluck","category":"List"},{"name":"prepend","category":"List"},{"name":"product","category":"Math"},{"name":"project","category":"Object"},{"name":"prop","category":"Object"},{"name":"propEq","category":"Relation"},{"name":"propIs","category":"Type"},{"name":"propOr","category":"Object"},{"name":"props","category":"Object"},{"name":"propSatisfies","category":"Logic"},{"name":"range","category":"List"},{"name":"reduce","category":"List"},{"name":"reduced","category":"List"},{"name":"reduceRight","category":"List"},{"name":"reject","category":"List"},{"name":"remove","category":"List"},{"name":"repeat","category":"List"},{"name":"replace","category":"String"},{"name":"reverse","category":"List"},{"name":"scan","category":"List"},{"name":"set","category":"Object"},{"name":"slice","category":"List"},{"name":"sort","category":"List"},{"name":"sortBy","category":"Relation"},{"name":"split","category":"String"},{"name":"splitEvery","category":"List"},{"name":"subtract","category":"Math"},{"name":"sum","category":"Math"},{"name":"T","category":"Function"},{"name":"tail","category":"List"},{"name":"take","category":"List"},{"name":"takeLast","category":"List"},{"name":"takeLastWhile","category":"List"},{"name":"takeWhile","category":"List"},{"name":"tap","category":"Function"},{"name":"test","category":"String"},{"name":"times","category":"List"},{"name":"toLower","category":"String"},{"name":"toPairs","category":"Object"},{"name":"toPairsIn","category":"Object"},{"name":"toString","category":"String"},{"name":"toUpper","category":"String"},{"name":"transduce","category":"List"},{"name":"trim","category":"String"},{"name":"type","category":"Type"},{"name":"unapply","category":"Function"},{"name":"unary","category":"Function"},{"name":"uncurryN","category":"Function"},{"name":"unfold","category":"List"},{"name":"union","category":"Relation"},{"name":"unionWith","category":"Relation"},{"name":"uniq","category":"List"},{"name":"uniqBy","category":"List"},{"name":"uniqWith","category":"List"},{"name":"unnest","category":"List"},{"name":"update","category":"List"},{"name":"useWith","category":"Function"},{"name":"values","category":"Object"},{"name":"valuesIn","category":"Object"},{"name":"view","category":"Object"},{"name":"where","category":"Object"},{"name":"whereEq","category":"Object"},{"name":"wrap","category":"Function"},{"name":"xprod","
-category":"List"},{"name":"zip","category":"List"},{"name":"zipObj","category":"List"},{"name":"zipWith","category":"List"}];
-    </script>
     <script src="dist/ramda.js"></script>
     <script src="main.js"></script>
 </body>

--- a/docs/main.js
+++ b/docs/main.js
@@ -68,10 +68,22 @@ function isTopLink(elem) {
   return elem.getAttribute('href') === '#';
 }
 
+function isAnchorLink(elem) {
+  return elem.tagName === 'A' && elem.getAttribute('href').charAt(0) === '#';
+}
+
+function closeNav() {
+  document.getElementById('open-nav').checked = false;
+}
+
 function dispatchEvent(event) {
   var target = event.target;
   var parent = target.parentNode;
   var category = target.getAttribute('data-category');
+
+  if (isAnchorLink(target)) {
+    closeNav();
+  }
   if (category) {
     filterTocType(category);
   }


### PR DESCRIPTION
https://github.com/ramda/ramda.github.io/pull/34#issuecomment-147574783:

> We've been pointing <http://ramdajs.com/docs/> at the current build's API docs. I thought that had been automated by the build, but it didn't happen here.

I had thought that this target would match __docs/index.html__:

```make
%: $(VERSION)/%
	cp '$<' '$@'
```

Apparently [`%`][1] does not perform matches across path components, so the target above matches __style.css__ but not __docs/index.html__.


[1]: https://www.gnu.org/software/make/manual/html_node/Static-Usage.html#Static-Usage
