### PR TITLE
better looking REPL

### DIFF
--- a/repl/assets/css/repl.css
+++ b/repl/assets/css/repl.css
@@ -70,5 +70,5 @@ body.dark, body.dark h1 {
 }
 
 .panel-primary .panel-body {
-    padding: 0 !important;
+    padding: 0;
 }

--- a/repl/assets/css/repl.css
+++ b/repl/assets/css/repl.css
@@ -60,3 +60,15 @@ body.dark, body.dark h1 {
     vertical-align: middle;
     margin-left: 6px;
 }
+
+.panel-primary {
+    border: none;
+}
+
+.panel-heading {
+    border-radius: 5px 5px 0px 0px;
+}
+
+.panel-primary .panel-body {
+    padding: 0 !important;
+}

--- a/repl/assets/css/repl.css
+++ b/repl/assets/css/repl.css
@@ -66,7 +66,7 @@ body.dark, body.dark h1 {
 }
 
 .panel-heading {
-    border-radius: 5px 5px 0px 0px;
+    border-radius: 5px 5px 0 0;
 }
 
 .panel-primary .panel-body {


### PR DESCRIPTION
The current REPL has a useless padding, which doesn't allow me to concentrate on my wonderful functional code:
![screenshot 2015-10-20 16 44 17](https://cloud.githubusercontent.com/assets/147684/10610834/ddb89e50-7749-11e5-93ca-69477fc58bfe.png)

When I remove it, i feel a lot better:
![screenshot 2015-10-20 16 44 03](https://cloud.githubusercontent.com/assets/147684/10610839/e05b975c-7749-11e5-84f6-2e5a8070d5f3.png)
