### PR TITLE
repl: remove "reset" button

### DIFF
--- a/repl/index.html
+++ b/repl/index.html
@@ -63,8 +63,7 @@
     <div class="container col-lg-12 theme-showcase">
 
         <div class="page-header">
-            <h1>Ramda REPL 
-<button id="resetBtn" class="btn btn-danger" type="reset">Reset</button>
+            <h1>Ramda REPL
 <button id="mkurl" class="btn btn-primary">Make Short URL:</button><input id="urlout" type="text" class="urltext" />
 </h1>
         </div>


### PR DESCRIPTION
As mentioned in #49, I see no reason to provide a UI element for emptying a textarea. Simply selecting the text and pressing <kbd>⌫</kbd> does the trick.
