### PR TITLE
Expose ramda functions as default on window

### DIFF
--- a/repl/lib/js/main.js
+++ b/repl/lib/js/main.js
@@ -9,3 +9,5 @@ const lift3 = ramdaFantasy.lift3;
 const Maybe = ramdaFantasy.Maybe;
 const Tuple = ramdaFantasy.Tuple;
 const Reader = ramdaFantasy.Reader;
+
+R.map(k => window[k] = R[k], R.keys(R))


### PR DESCRIPTION
This change allows REPL users to use ramda functions without prefixing `R.` by pushing them onto `window`