### PR TITLE
Larger code viewing area

### DIFF
--- a/repl/index.html
+++ b/repl/index.html
@@ -39,34 +39,32 @@
 <body>
     <!-- Fixed navbar -->
     <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-        <div class="container col-lg-12">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </button>
-		<a class="navbar-brand" href="http://ramdajs.com"><strong>Ramda </strong><span class="version">v0.21.0</span></a>
-            </div>
-            <div class="navbar-collapse collapse">
-                <ul class="nav navbar-nav">
-                    <li><a href="/">Home</a></li>
-                    <li><a href="/docs">Documentation</a></li>
-		    <li class="active"><a href="/repl?v=0.21.0">Try Ramda</a></li>
-                    <li><a href="https://github.com/ramda/ramda">GitHub</a></li>
-                </ul>
-            </div>
-            <!--/.nav-collapse -->
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="http://ramdajs.com"><strong>Ramda </strong><span class="version">v0.21.0</span></a>
         </div>
+        <div class="navbar-collapse collapse">
+            <ul class="nav navbar-nav">
+                <li><a href="/">Home</a></li>
+                <li><a href="/docs">Documentation</a></li>
+                <li class="active"><a href="/repl?v=0.21.0">Try Ramda</a></li>
+                <li><a href="https://github.com/ramda/ramda">GitHub</a></li>
+            </ul>
+        </div>
+        <!--/.nav-collapse -->
     </div>
-    <div class="container col-lg-12 theme-showcase">
 
-        <div class="page-header">
-            <h1>Ramda REPL
-<button id="resetBtn" class="btn btn-danger" type="reset">Reset</button>
-<button id="mkurl" class="btn btn-primary">Make Short URL:</button><input id="urlout" type="text" class="urltext" />
-</h1>
+    <div id="midline" class="hidden-sm hidden-xs"></div>
+
+    <div class="col-lg-12">
+        <div>
+            <button id="resetBtn" class="btn btn-danger btn-xs" type="reset">Reset</button>
+            <button id="mkurl" class="btn btn-primary btn-xs">Make Short URL:</button><input id="urlout" type="text" class="urltext" />
         </div>
         <div class="row">
             <div class="col-md-6">
@@ -82,8 +80,8 @@
             <div class="col-md-6">
                 <div class="panel panel-primary">
                     <div class="panel-heading">
-                        <h3 class="panel-title output">Output</h3>
-                        <button class="btn btn-link btn-xs clear-console" type="button">Clear Output</button>
+                        <h3 class="panel-title">Output</h3>
+                        <button class="btn btn-link clear-console" type="button">Clear Output</button>
                     </div>
                     <div class="panel-body">
                         <pre class="error"></pre>

--- a/repl/index.html.handlebars
+++ b/repl/index.html.handlebars
@@ -39,34 +39,32 @@
 <body>
     <!-- Fixed navbar -->
     <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-        <div class="container col-lg-12">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </button>
-		<a class="navbar-brand" href="http://ramdajs.com"><strong>Ramda </strong><span class="version">v{{version}}</span></a>
-            </div>
-            <div class="navbar-collapse collapse">
-                <ul class="nav navbar-nav">
-                    <li><a href="/">Home</a></li>
-                    <li><a href="/docs">Documentation</a></li>
-		    <li class="active"><a href="/repl?v={{version}}">Try Ramda</a></li>
-                    <li><a href="https://github.com/ramda/ramda">GitHub</a></li>
-                </ul>
-            </div>
-            <!--/.nav-collapse -->
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+	        <a class="navbar-brand" href="http://ramdajs.com"><strong>Ramda </strong><span class="version">v{{version}}</span></a>
         </div>
+        <div class="navbar-collapse collapse">
+            <ul class="nav navbar-nav">
+                <li><a href="/">Home</a></li>
+                <li><a href="/docs">Documentation</a></li>
+	            <li class="active"><a href="/repl?v={{version}}">Try Ramda</a></li>
+                <li><a href="https://github.com/ramda/ramda">GitHub</a></li>
+            </ul>
+        </div>
+        <!--/.nav-collapse -->
     </div>
-    <div class="container col-lg-12 theme-showcase">
 
-        <div class="page-header">
-            <h1>Ramda REPL
-<button id="resetBtn" class="btn btn-danger" type="reset">Reset</button>
-<button id="mkurl" class="btn btn-primary">Make Short URL:</button><input id="urlout" type="text" class="urltext" />
-</h1>
+    <div id="midline" class="hidden-sm hidden-xs"></div>
+
+    <div class="col-lg-12">
+        <div>
+            <button id="resetBtn" class="btn btn-danger btn-xs" type="reset">Reset</button>
+            <button id="mkurl" class="btn btn-primary btn-xs">Make Short URL:</button><input id="urlout" type="text" class="urltext" />
         </div>
         <div class="row">
             <div class="col-md-6">
@@ -82,8 +80,8 @@
             <div class="col-md-6">
                 <div class="panel panel-primary">
                     <div class="panel-heading">
-                        <h3 class="panel-title output">Output</h3>
-                        <button class="btn btn-link btn-xs clear-console" type="button">Clear Output</button>
+                        <h3 class="panel-title">Output</h3>
+                        <button class="btn btn-link clear-console" type="button">Clear Output</button>
                     </div>
                     <div class="panel-body">
                         <pre class="error"></pre>

--- a/repl/lib/css/repl.css
+++ b/repl/lib/css/repl.css
@@ -4,6 +4,23 @@ html, body {
     margin: 0;
     padding-top: 30px;
     padding-bottom: 30px;
+    background-color: #282a36;
+    height: 100%;
+}
+
+pre {
+    padding: 0;
+    padding-left: 20px;
+}
+
+#midline {
+    position: fixed;
+    left: 50%;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    z-index: 1;
+    background-color: gray;
 }
 
 .output-wrapper {
@@ -14,9 +31,6 @@ html, body {
 
 html.hide-output .output-wrapper {
     display: none;
-}
-
-html.hide-output .CodeMirror {
 }
 
 .eval, .source-map {
@@ -55,6 +69,8 @@ body.dark, body.dark h1 {
     color: #ffffff;
 }
 .urltext {
+    background-color: #282a36;
+    color: white;
     border: none;
     font-size: 15px;
     vertical-align: middle;

--- a/repl/lib/css/terminal.css
+++ b/repl/lib/css/terminal.css
@@ -1,30 +1,22 @@
-.CodeMirror {
-    height: 500px;
-}
-
 .CodeMirror-hscrollbar {
     display: none !important;
+}
+
+.CodeMirror {
+    height: 100%;
 }
 
 .right .github-fork-ribbon {
     background-color: #29357F;
 }
 
-
-.output, .clear-console {
-    float:left;
-}
 .clear-console  {
     margin-left: 12px;
 }
+
 .top-nav {
     background: #6F377D;
     height:15px;
-}
-
-.col-md-6:last-of-type {
-    border-left: 1px solid #999;
-    min-height: 42em;
 }
 
 .page-header {
@@ -48,11 +40,17 @@
     color:#fff;
 }
 
+.panel-title {
+    display: inline-block;
+}
+
+.panel-body {
+    padding: 0;
+}
+
 .panel {
     background-color: #282a36;
 }
-
-
 
 .eval, .source-map, .console-log {
     background-color: #282a36;
@@ -63,7 +61,6 @@
 .console-log {
     color:#888;
 }
-
 
 .error {
     background: #282a36;


### PR DESCRIPTION
This PR focuses on providing larger code viewing area for the REPL by removing or compacting the size of some page elements. It also has an improved viewing experience for small window sizes.

![large](https://cloud.githubusercontent.com/assets/8955144/15694986/c1bed854-2770-11e6-9225-79c7b01d8347.png)

Small screen comparison between current and this PR:
![small_compare](https://cloud.githubusercontent.com/assets/8955144/15695005/e3575b8a-2770-11e6-9d72-9646222c6f20.PNG)

Notes
- I get 403 from google for the "Make Short URL" button. I would guess the uri key just doesn't work for my origin.
- Still confused about the build process. I  tried a test run using `VERSION=0.21.0 make` from the parent folder to see if an edit in `repl/index.html.handlebars` would build into a new `repl/index.html`, but that didn't appear to work. (So I hand copied between html and handlebars file :hammer: )