### PR TITLE
Add copy ramda.js script

### DIFF
--- a/copy_ramda_js.js
+++ b/copy_ramda_js.js
@@ -1,0 +1,11 @@
+var fs = require('fs')
+
+var get_ramda_file = require('./get_ramda_file')
+
+var path = require('path')
+
+get_ramda_file(path.join('dist', 'ramda.js'))
+.catch((err) => console.error(err))
+.then((ramda_js) => {
+  fs.writeFileSync(path.join('docs', 'dist', 'ramda.js'), ramda_js, {encoding: 'utf8'})
+})

--- a/get_ramda_file.js
+++ b/get_ramda_file.js
@@ -1,0 +1,18 @@
+var fs = require('fs')
+
+var path = require('path')
+
+module.exports = (child_path) => new Promise ((resolve, reject) => {
+  var ramda_module_path = require.resolve('ramda')
+
+  var ramda_folder = path.normalize(path.join(ramda_module_path, '..', '..'))
+
+  var file_path = path.join(ramda_folder, child_path)
+
+  fs.readFile(file_path, 'utf8', (err, data) => {
+    if (err)
+      reject(err)
+    else
+      resolve(data)
+  })
+})


### PR DESCRIPTION
Adds a script (`copy_ramda_js.js`) that will copy the ramda.js file from the `node_modules` folder and into the repository.
This is the other part of #77, following on from #86.