### PR TITLE
Add copy to version folder script

### DIFF
--- a/copy_to_version_folder.js
+++ b/copy_to_version_folder.js
@@ -1,0 +1,39 @@
+var fs = require('fs')
+
+var path = require('path')
+
+var version = require('./package.json').devDependencies.ramda
+
+var walk = require('walk')
+
+var copy_file = (source, destination) => new Promise((resolve, reject) => {
+  fs.createReadStream(source)
+  .pipe(fs.createWriteStream(destination))
+  .on('close', resolve)
+  .on('error', reject)
+})
+
+fs.mkdir(version, (err) => {
+  walk.walk('./docs')
+  .on('end', () => {
+    console.log('Copying docs folder done.')
+
+    copy_file('index.html', path.join(version, 'index.html'))
+    .then(copy_file('style.css', path.join(version, 'style.css')))
+    .then(copy_file('package.json', path.join(version, 'package.json')))
+    .then((result) => console.log('Copied files.'))
+    .catch((err) => console.error(err))
+  })
+  .on('errors', (root, node_stats_array, next) => {
+    console.error('Error copying files.')
+  })
+  .on('file', (root, file_stats, next) => {
+    fs.mkdir(path.join(version, root), (err) => {
+      copy_file(path.join(root, file_stats.name), path.join(version, root, file_stats.name))
+      .catch((err) => console.error(err))
+      .then((result) => {
+        next()
+      })
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "jsdoc": "3.3.x",
     "less": "2.5.x",
     "marked": "0.3.x",
-    "ramda": "0.22.1"
+    "ramda": "0.22.1",
+    "walk": "^2.3.9"
   },
   "scripts": {
     "jsdoc": "jsdoc --destination ./docs --template . ./docs/dist/ramda.js",


### PR DESCRIPTION
Creates a folder named as the Ramda version number and then copies documentation into it.

Run with `node copy_to_version_folder.js`.