### PR TITLE
Add make index.html script

### DIFF
--- a/make_index_html.js
+++ b/make_index_html.js
@@ -1,0 +1,24 @@
+var fs = require('fs')
+
+var get_ramda_file = require('./get_ramda_file')
+
+var handlebars = require('handlebars')
+
+var marked = require('marked')
+
+var version = require('./package.json').devDependencies.ramda
+
+get_ramda_file('README.md')
+.catch((err) => console.error(err))
+.then((readme_md) => {
+  var readme_html = marked(readme_md)
+
+  var template = fs.readFileSync('index.html.handlebars', {encoding: 'utf8'})
+
+  var html = handlebars.compile(template)({
+    readme: new handlebars.SafeString(readme_html),
+    version: version
+  })
+
+  fs.writeFileSync('index.html', html, {encoding: 'utf8'})
+})


### PR DESCRIPTION
This requires `get_ramda_file.js` from #91 and the index template moved in #90.

Use `node make_index_html.js` to create `index.html` using `index.html.handlebars` and `README.md` (from the `ramda` repo).