### PR TITLE
Small fixes to last two immutability code snippets

### DIFF
--- a/manual/01-intro/Immutability.md
+++ b/manual/01-intro/Immutability.md
@@ -136,7 +136,7 @@ the same case without introducing such continual mutation:
 R.reduce((accum, state) => notSmall(state) ? 
                            R.assoc(state.symbol, state.pop, accum) : 
                            accum,
-{}, states),  //=> {"CT": 3574097, "MA": 6547629}
+{}, states);  //=> {"CT": 3574097, "MA": 6547629}
 ```
 
 And, unless it caused performance concerns, many Ramda users would
@@ -146,9 +146,8 @@ transformations:
 ```js
 R.pipe(
     R.filter(notSmall), 
-    R.props(['symbol', 'pop']),
-    R.fromPairs
-)(states) //=> {"CT": 3574097, "MA": 6547629}
+    R.map(R.props(['symbol', 'pop'])),
+    R.fromPairs)(states) //=> {"CT": 3574097, "MA": 6547629}
 ```
 
 In the section on [Transducers][tr] we'll examine how to make such


### PR DESCRIPTION
I've been working through the manual trying the code snippets out in the node repl; this PR fixes the last two snippets on the Immutability page which failed.

* Replace comma with semicolon in "reduce without mutation" example
* Map `R.props` over filtered states in piped example and make code layout suitable for pasting in node repl