### PR TITLE
Don't copy docs main.js to index directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,6 @@ $(VERSION)/docs/index.html $(VERSION)/index.html: $(JSDOC_FILES)
 	  --template '$(<D)' \
 	  '$(VERSION)/docs/dist/ramda.js'
 
-$(VERSION)/docs/main.js: main.js
-	mkdir -p '$(@D)'
-	cp '$<' '$@'
-
 $(VERSION)/fonts/%: node_modules/bootstrap/fonts/%
 	mkdir -p '$(@D)'
 	cp '$<' '$@'


### PR DESCRIPTION
Now there is no index page, because when user visits `/` he is auto
redirected to `/<version>/docs` page.

Prevents #105 from happening again