### PR TITLE
Fix #96 Ensure codemirror is full height

### DIFF
--- a/repl/index.html
+++ b/repl/index.html
@@ -61,13 +61,13 @@
 
     <div id="midline" class="hidden-sm hidden-xs"></div>
 
-    <div class="col-lg-12">
+    <div class="main col-lg-12">
         <div>
             <button id="resetBtn" class="btn btn-danger btn-xs" type="reset">Reset</button>
             <button id="mkurl" class="btn btn-primary btn-xs">Make Short URL:</button><input id="urlout" type="text" class="urltext" />
         </div>
-        <div class="row">
-            <div class="col-md-6">
+        <div class="repl row">
+            <div class="repl-input col-md-6">
                 <div class="panel panel-primary">
                     <div class="panel-heading">
                         <h3 class="panel-title">Input</h3>

--- a/repl/index.html.handlebars
+++ b/repl/index.html.handlebars
@@ -61,13 +61,13 @@
 
     <div id="midline" class="hidden-sm hidden-xs"></div>
 
-    <div class="col-lg-12">
+    <div class="main col-lg-12">
         <div>
             <button id="resetBtn" class="btn btn-danger btn-xs" type="reset">Reset</button>
             <button id="mkurl" class="btn btn-primary btn-xs">Make Short URL:</button><input id="urlout" type="text" class="urltext" />
         </div>
-        <div class="row">
-            <div class="col-md-6">
+        <div class="repl row">
+            <div class="repl-input col-md-6">
                 <div class="panel panel-primary">
                     <div class="panel-heading">
                         <h3 class="panel-title">Input</h3>

--- a/repl/lib/css/repl.css
+++ b/repl/lib/css/repl.css
@@ -76,3 +76,38 @@ body.dark, body.dark h1 {
     vertical-align: middle;
     margin-left: 6px;
 }
+
+@media (min-width: 991px) {
+  .main {
+      display: flex;
+      flex-direction: column;
+      flex: 1 0 auto;
+      height : 100%;
+      border: 4px;
+  }
+
+  .repl {
+      display: flex;
+      flex: 1 0 auto;
+  }
+
+  .repl-input {
+      flex: 1 0 auto;
+  }
+
+  .repl-input .panel-primary {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+  }
+
+  .repl-input .panel-body {
+      flex: 1 0 auto;
+      display: flex;
+  }
+
+  .repl-input .CodeMirror {
+      height: auto;
+      flex: 1 0 auto;
+  }
+}


### PR DESCRIPTION
Relates to issue #96 

This PR adds some extra CSS classes and rules with the objective of making the elements containing the `CodeMirror` have a full height, thereby increasing the click target for giving focus to the `CodeMirror`.

Tested on modern versions of Chrome, Firefox and Microsoft Edge.