### PR TITLE
Missing vendor prefixes 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ $(VERSION)/fonts/%: node_modules/bootstrap/fonts/%
 
 $(VERSION)/style.css: $(LESS_FILES)
 	mkdir -p '$(@D)'
-	$(LESS) less/ramda.less --autoprefix >'$@'
+	$(LESS) less/ramda.less --autoprefix --clean-css >'$@'
 
 docs/%: $(VERSION)/docs/%
 	mkdir -p '$(@D)'

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ $(VERSION)/fonts/%: node_modules/bootstrap/fonts/%
 
 $(VERSION)/style.css: $(LESS_FILES)
 	mkdir -p '$(@D)'
-	$(LESS) less/ramda.less >'$@'
+	$(LESS) less/ramda.less --autoprefix >'$@'
 
 docs/%: $(VERSION)/docs/%
 	mkdir -p '$(@D)'

--- a/browserslist
+++ b/browserslist
@@ -1,0 +1,5 @@
+Last 2 versions
+Android >= 4.0
+Explorer >= 9
+iOS >= 4.3
+Safari >= 5

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "jsdoc": "3.3.x",
     "less": "2.7.x",
     "less-plugin-autoprefix": "^1.5.1",
+    "less-plugin-clean-css": "^1.5.1",
     "marked": "0.3.x",
     "ramda": "0.22.1",
     "semver-compare": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "http-server": "^0.9.0",
     "jsdoc": "3.3.x",
     "less": "2.7.x",
+    "less-plugin-autoprefix": "^1.5.1",
     "marked": "0.3.x",
     "ramda": "0.22.1",
     "semver-compare": "^1.0.0",


### PR DESCRIPTION
Some vendor prefixes are missing (e.g: `-webkit-transform`). This is causing issues especially on mobile (iOS < 9, Android < 4.3): https://github.com/ramda/ramda.github.io/issues/41.

[Autoprefixer](https://github.com/less/less-plugin-autoprefix) automatically adds these prefixes to css after conversion from less. The targeted browsers are listed in the `browserslist` config file.
The browser versions are based on what's specified for the unit tests:

- https://github.com/ramda/ramda/blob/master/lib/sauce/android.js
- https://github.com/ramda/ramda/blob/master/lib/sauce/apple.js
- https://github.com/ramda/ramda/blob/master/lib/sauce/ios.js

To mitigate the increased file size after autoprefixing (before: 147kb, after: 152kb) I've added minification to the build process as well. This reduces css file size to 126kb (autoprefixing included)