### PR TITLE
Fix try in REPL link in docs

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -106,7 +106,7 @@
     var code = event.target.nextElementSibling.textContent;
     var encoded = fixedEncodeURIComponent(code);
     location.assign(location.origin + '/repl/' +
-      versionParam + '#?code=' + encoded);
+      versionParam + '#;' + encoded);
   }
 
 


### PR DESCRIPTION
Fixes #144

This contains a hack to deal with the REPL discarding the first character.

The semicolon should ensure the code is still valid if the first character is included later.