### PR TITLE
Remove unused symb section from docs page

### DIFF
--- a/docs/index.html.handlebars
+++ b/docs/index.html.handlebars
@@ -111,25 +111,6 @@
 
             <div class="description">{{{description}}}</div>
 
-            {{#if symb}}
-            <table class="table table-sm">
-                <thead>
-                    <tr>
-                        <th>Input</th>
-                        <th>Output</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {{#each symb}}
-                    <tr>
-                        <td><pre class="symbol">{{input}}</pre></td>
-                        <td><pre class="symbol">{{output}}</pre></td>
-                    </tr>
-                    {{/each}}
-                </tbody>
-            </table>
-            {{/if}}
-
             {{#if aka}}
             <div class="aka">
                 Known in other languages or libraries as


### PR DESCRIPTION
I cannot seem to find this being used on the site, not even in the older versions of the docs.

There are some styles for it that I have removed in another branch for a later PR.