### PR TITLE
Remove ramdocs redirects

### DIFF
--- a/ramdocs/docs/index.html
+++ b/ramdocs/docs/index.html
@@ -1,5 +1,0 @@
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://ramdajs.com/docs">
-  </head>
-</html>

--- a/ramdocs/index.html
+++ b/ramdocs/index.html
@@ -1,5 +1,0 @@
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=http://ramdajs.com/">
-  </head>
-</html>


### PR DESCRIPTION
Just thought I'd see if the `ramdocs` redirects were still needed.