### PR TITLE
Enable loading of external scripts

### DIFF
--- a/repl/index.html
+++ b/repl/index.html
@@ -113,8 +113,7 @@
           // Optional.
           // Here we can declare a list of libraries that we wish to have
           // loaded and exposed in the repl.
-          scripts: []
-            /*
+
           scripts: [
             {
               src      : '//wzrd.in/standalone/sanctuary@latest',
@@ -137,8 +136,6 @@
               ]
             }
           ]
-          */
-
         });
 
       }());


### PR DESCRIPTION
The URLs seems to be working and the globals S and ramdaFantasy are exposed in the REPL