### PR TITLE
Load Ramda Fantasy and Sanctuary scripts again

### DIFF
--- a/repl/index.html
+++ b/repl/index.html
@@ -113,8 +113,6 @@
           // Optional.
           // Here we can declare a list of libraries that we wish to have
           // loaded and exposed in the repl.
-          scripts: []
-            /*
           scripts: [
             {
               src      : '//wzrd.in/standalone/sanctuary@latest',
@@ -137,7 +135,6 @@
               ]
             }
           ]
-          */
 
         });
 


### PR DESCRIPTION
The REPL seems to handle broken scripts, so there's no reason not to try any more.