### PR TITLE
Support versioning of ramda-repl js file

### DIFF
--- a/repl/index.html
+++ b/repl/index.html
@@ -16,7 +16,7 @@
     <link href="css/page.css" rel="stylesheet">
 
     <!-- Style for the REPL -->
-    <link href="https://cdn.rawgit.com/ramda/repl/master/dist/bundle.css" rel="stylesheet">
+    <link href="https://cdn.rawgit.com/ramda/repl/1.1.0/dist/bundle.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -53,7 +53,7 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.18.1/URI.min.js"></script>
-    <script src="https://cdn.rawgit.com/ramda/repl/master/dist/bundle.js"></script>
+    <script src="https://cdn.rawgit.com/ramda/repl/1.1.0/dist/bundle.js"></script>
 
     <script>
 

--- a/repl/index.pug
+++ b/repl/index.pug
@@ -6,8 +6,8 @@ block main
 
 block scripts
 	script(src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.18.1/URI.min.js")
-	script(src="https://cdn.rawgit.com/ramda/repl/master/dist/bundle.js")
+	script(src="https://cdn.rawgit.com/ramda/repl/1.1.0/dist/bundle.js")
 	script(src="index.js")
 
 block styles
-	link(href="https://cdn.rawgit.com/ramda/repl/master/dist/bundle.css" rel="stylesheet")
+	link(href="https://cdn.rawgit.com/ramda/repl/1.1.0/dist/bundle.css" rel="stylesheet")


### PR DESCRIPTION
We started to use `rawgit` since https://github.com/ramda/ramda.github.io/pull/136. From the comment in https://github.com/ramda/repl/pull/50#issuecomment-331756404, [rawgit faq](https://github.com/rgrove/rawgit/blob/master/FAQ.md#how-long-does-the-cdn-cache-files-how-can-i-make-it-refresh-my-file) does not recommend using `master` as the tag as they do not clear cache. 

This PR attempts to use tag from `ramda-repl` instead of always using `master` to overcome this issue.

I also added a util script to generate the repl/index.html from handlerbars. Sorry that I could not figure out how to use the new pug based template introduced in https://github.com/ramda/ramda.github.io/pull/175. It also looks like the current repl/index.html has been manually modified in the past few commits. Feel free to update the pug template to support the same, if this PR is accepted.  @MattMS 

TODO:
 * [ ] merge https://github.com/ramda/repl/pull/51 and upload 1.1.0 of ramda/repl

@craigdallimore @buzzdecafe 