### PR TITLE
Fixing source-code links (Closes #197)

### DIFF
--- a/docs/index.html.handlebars
+++ b/docs/index.html.handlebars
@@ -62,7 +62,7 @@
                 <a tabindex="2" class="name" href="#{{name}}">{{name}}</a>
                 <span class="pull-right">
                         <span class="label label-category">{{category}}</span>
-                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v{{../version}}/src/{{name}}.js"><small class="glyphicon glyphicon-new-window"></small></a>
+                        <a target="_blank" title="View source on GitHub" href="https://github.com/ramda/ramda/tree/v{{../version}}/source/{{name}}.js"><small class="glyphicon glyphicon-new-window"></small></a>
                 </span>
             </h2>
 


### PR DESCRIPTION
We broke the links to the source code in the docs when we moved from `src` to `source`.