### PR TITLE
Revert "Revert "Support versioning of ramda-repl js file""

### DIFF
--- a/repl/index.html
+++ b/repl/index.html
@@ -16,7 +16,7 @@
     <link href="css/page.css" rel="stylesheet">
 
     <!-- Style for the REPL -->
-    <link href="https://cdn.rawgit.com/ramda/repl/master/dist/bundle.css" rel="stylesheet">
+    <link href="https://cdn.rawgit.com/ramda/repl/1.1.0/dist/bundle.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -53,7 +53,7 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.18.1/URI.min.js"></script>
-    <script src="https://cdn.rawgit.com/ramda/repl/master/dist/bundle.js"></script>
+    <script src="https://cdn.rawgit.com/ramda/repl/1.1.0/dist/bundle.js"></script>
 
     <script>
 

--- a/repl/index.pug
+++ b/repl/index.pug
@@ -6,8 +6,8 @@ block main
 
 block scripts
 	script(src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.18.1/URI.min.js")
-	script(src="https://cdn.rawgit.com/ramda/repl/master/dist/bundle.js")
+	script(src="https://cdn.rawgit.com/ramda/repl/1.1.0/dist/bundle.js")
 	script(src="index.js")
 
 block styles
-	link(href="https://cdn.rawgit.com/ramda/repl/master/dist/bundle.css" rel="stylesheet")
+	link(href="https://cdn.rawgit.com/ramda/repl/1.1.0/dist/bundle.css" rel="stylesheet")


### PR DESCRIPTION
This reverts PR #194, which is a revert of #190 

* [ ] create 1.1.0 tag in ramda/repl first (https://github.com/ramda/repl/pull/51#issuecomment-345327078)