### PR TITLE
fix: Disable autocompletion for the search input in Safari

### DIFF
--- a/docs/index.html.handlebars
+++ b/docs/index.html.handlebars
@@ -36,6 +36,7 @@
                    placeholder="Filter"
                    type="text"
                    data-bind="textInput: filter"
+		   autocomplete="false"
                    autofocus
             >
             <span class="form-control-feedback">


### PR DESCRIPTION
Safari tries to autofill the input without the `autocomplete="false"`