### PR TITLE
Add Either and Maybe to RunKit embeds

### DIFF
--- a/0.25.0/docs/main.js
+++ b/0.25.0/docs/main.js
@@ -134,7 +134,7 @@
     RunKit.createNotebook({
         element: container,
         nodeVersion: '*',
-        preamble: 'var R = require("ramda' + ramdaVersion + '")',
+        preamble: 'var { Maybe, Either } = require("ramda-fantasy");\nvar R = require("ramda' + ramdaVersion + '");',
         source: codeElement.textContent,
         theme: 'atom-dark',
         minHeight: "52px",

--- a/0.26.0/docs/main.js
+++ b/0.26.0/docs/main.js
@@ -134,7 +134,7 @@
     RunKit.createNotebook({
         element: container,
         nodeVersion: '*',
-        preamble: 'var R = require("ramda' + ramdaVersion + '")',
+        preamble: 'var { Maybe, Either } = require("ramda-fantasy");\nvar R = require("ramda' + ramdaVersion + '");',
         source: codeElement.textContent,
         theme: 'atom-dark',
         minHeight: "52px",

--- a/0.26.1/docs/main.js
+++ b/0.26.1/docs/main.js
@@ -134,7 +134,7 @@
     RunKit.createNotebook({
         element: container,
         nodeVersion: '*',
-        preamble: 'var R = require("ramda' + ramdaVersion + '")',
+        preamble: 'var { Maybe, Either } = require("ramda-fantasy");\nvar R = require("ramda' + ramdaVersion + '");',
         source: codeElement.textContent,
         theme: 'atom-dark',
         minHeight: "52px",

--- a/docs/main.js
+++ b/docs/main.js
@@ -134,7 +134,7 @@
     RunKit.createNotebook({
         element: container,
         nodeVersion: '*',
-        preamble: 'var R = require("ramda' + ramdaVersion + '")',
+        preamble: 'var { Maybe, Either } = require("ramda-fantasy");\nvar R = require("ramda' + ramdaVersion + '");',
         source: codeElement.textContent,
         theme: 'atom-dark',
         minHeight: "52px",


### PR DESCRIPTION
This brings `Either` and `Maybe` into scope for RunKit embeds. I back-ported it to 0.25.0 and 0.26.0 (along with the current 0.26.1) to support all the versions that have used RunKit embeds.