### PR TITLE
Use https for Randy Coulman's Thinking in Ramda

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ to be operated on is generally supplied last.</p>
 <li><a href="http://fr.umio.us/favoring-curry/">Favoring Curry</a> by Scott Sauyet</li>
 <li><a href="https://hughfdjackson.com/javascript/why-curry-helps/">Why Curry Helps</a> by Hugh Jackson</li>
 <li><a href="https://www.youtube.com/watch?v=m3svKOdZijA&amp;app=desktop">Hey Underscore, You&#39;re Doing It Wrong!</a> by Brian Lonsdorf</li>
-<li><a href="http://randycoulman.com/blog/categories/thinking-in-ramda">Thinking in Ramda</a> by Randy Coulman</li>
+<li><a href="https://randycoulman.com/blog/categories/thinking-in-ramda">Thinking in Ramda</a> by Randy Coulman</li>
 </ul>
 <h2 id="philosophy">Philosophy</h2>
 <p>Using Ramda should feel much like just using JavaScript.


### PR DESCRIPTION
Thanks again for linking to my Thinking in Ramda blog series from this page! I get a lot of positive feedback on the series, and it looks like most people find it via this link.

I've just updated my site to use https, so this updates the link series to be https instead of http.

Apologies for the spurious extra newline at the end of the diff.  I submitted this directly using GitHub's UI and they must have added it.