### PR TITLE
bump up repl version to 1.2.0 to use tinyurl for url shortening

### DIFF
--- a/repl/index.html
+++ b/repl/index.html
@@ -16,7 +16,7 @@
     <link href="css/page.css" rel="stylesheet">
 
     <!-- Style for the REPL -->
-    <link href="https://cdn.rawgit.com/ramda/repl/1.1.0/dist/bundle.css" rel="stylesheet">
+    <link href="https://cdn.rawgit.com/ramda/repl/1.2.0/dist/bundle.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -53,7 +53,7 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.18.1/URI.min.js"></script>
-    <script src="https://cdn.rawgit.com/ramda/repl/1.1.0/dist/bundle.js"></script>
+    <script src="https://cdn.rawgit.com/ramda/repl/1.2.0/dist/bundle.js"></script>
 
     <script>
 
@@ -82,7 +82,7 @@
 
         ramdaRepl(document.querySelector('.ramda-repl-target'), {
 
-          apiUrl: 'https://www.googleapis.com/urlshortener/v1/url?key=AIzaSyDhbAvT5JqkxFPkoeezJp19-S_mAJudxyk',
+          apiUrl: 'https://tinyurl.com/api-create.php',
           returnUrl: 'http://ramdajs.com/repl/',
 
           // If unset, initialValue will use the value or textcontent of the

--- a/repl/index.pug
+++ b/repl/index.pug
@@ -6,8 +6,8 @@ block main
 
 block scripts
 	script(src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.18.1/URI.min.js")
-	script(src="https://cdn.rawgit.com/ramda/repl/1.1.0/dist/bundle.js")
+	script(src="https://cdn.rawgit.com/ramda/repl/1.2.0/dist/bundle.js")
 	script(src="index.js")
 
 block styles
-	link(href="https://cdn.rawgit.com/ramda/repl/1.1.0/dist/bundle.css" rel="stylesheet")
+	link(href="https://cdn.rawgit.com/ramda/repl/1.2.0/dist/bundle.css" rel="stylesheet")


### PR DESCRIPTION
This is to bump up the version of repl to 1.2.0 to bring in the changes for using tinyurl as the url shortener to replace the now defunct google one.

See https://github.com/ramda/repl/pull/69 

* [ ] ⚠️ Create a tag in https://github.com/ramda/repl first ⚠️ 