### PR TITLE
fixes repl loading ramda-fantasy types

### DIFF
--- a/repl/index.html
+++ b/repl/index.html
@@ -121,8 +121,8 @@
               exposeAs : 'S'
             },
             {
-              src    : '//cdn.jsdelivr.net/npm/ramda-fantasy@0.8.0/dist/ramda-fantasy.min.js',
-              global : 'ramdaFantasy',
+              src    : '//cdn.jsdelivr.net/npm/ramda-fantasy@latest/dist/ramda-fantasy.min.js',
+              global : 'RF',
               expose : [
                 'Either',
                 'Future',

--- a/repl/index.html.handlebars
+++ b/repl/index.html.handlebars
@@ -122,7 +122,7 @@
             },
             {
               src    : '//cdn.jsdelivr.net/npm/ramda-fantasy@0.8.0/dist/ramda-fantasy.min.js',
-              global : 'ramdaFantasy',
+              global : 'RF',
               expose : [
                 'Either',
                 'Future',

--- a/repl/index.js
+++ b/repl/index.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', function () {
       {
         exposeAs: 'S',
         global: 'sanctuary',
-        src: '//wzrd.in/standalone/sanctuary@latest'
+        src: '//cdn.jsdelivr.net/gh/sanctuary-js/sanctuary@latest/dist/bundle.js'
       },
       {
         expose: [
@@ -66,8 +66,8 @@ document.addEventListener('DOMContentLoaded', function () {
           'Reader',
           'Tuple'
         ],
-        global: 'ramdaFantasy',
-        src: '//wzrd.in/standalone/ramda-fantasy@latest'
+        global: 'RF',
+        src: '//cdn.jsdelivr.net/npm/ramda-fantasy@latest/dist/ramda-fantasy.min.js'
       }
     ]
   })


### PR DESCRIPTION
This probably happened at some point when changing the cdn. Also changed the url to point to `@latest` like sanctuary, although this is not probably not very relevant for `ramda-fantasy`.