### PR TITLE
bugfix: fix Filter no category

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -15,6 +15,7 @@ const {
   propEq,
   replace,
   split,
+  __
 } = require('ramda');
 
 const handlebars = require('handlebars');
@@ -45,7 +46,7 @@ const prettifySig = pipe(
 //  Handles any combination of comma-separated and multi-line @see annotations.
 const simplifySee = pipe(chain(split(/\s*,\s*/)), map(replace(/^R[.]/, '')))
 
-const titleFilter = pipe(propEq('title'), filter)
+const titleFilter = pipe(propEq(__, 'title'), filter)
 
 const valueProp = chain(prop('value'))
 


### PR DESCRIPTION
@kedashoe Ramda Doc use `R.propEq` to filter every functions' "category" tag, and ramda swap `R.propEq` parameters order in v0.29.0, this is the reason Ramda Doc lost "category" tag.

We need to merge this pr, and republish ramda doc.