### PR TITLE
fix(documentation): Corrected typo in API Docs page title

### DIFF
--- a/0.25.0/docs/index.html
+++ b/0.25.0/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.25.0/docs/index.html.handlebars
+++ b/0.25.0/docs/index.html.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.26.0/docs/index.html
+++ b/0.26.0/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.26.0/docs/index.html.handlebars
+++ b/0.26.0/docs/index.html.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.26.1/docs/index.html
+++ b/0.26.1/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.26.1/docs/index.html.handlebars
+++ b/0.26.1/docs/index.html.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.27.0/docs/index.html
+++ b/0.27.0/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.27.0/docs/index.html.handlebars
+++ b/0.27.0/docs/index.html.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.27.1/docs/index.html
+++ b/0.27.1/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.27.1/docs/index.html.handlebars
+++ b/0.27.1/docs/index.html.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.27.2/docs/index.html
+++ b/0.27.2/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.27.2/docs/index.html.handlebars
+++ b/0.27.2/docs/index.html.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.28.0/docs/index.html
+++ b/0.28.0/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.28.0/docs/index.html.handlebars
+++ b/0.28.0/docs/index.html.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.29.0/docs/index.html
+++ b/0.29.0/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.29.0/docs/index.html.handlebars
+++ b/0.29.0/docs/index.html.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.29.1/docs/index.html
+++ b/0.29.1/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.29.1/docs/index.html.handlebars
+++ b/0.29.1/docs/index.html.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.30.0/docs/index.html
+++ b/0.30.0/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.30.0/docs/index.html.handlebars
+++ b/0.30.0/docs/index.html.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.30.1/docs/index.html
+++ b/0.30.1/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/0.30.1/docs/index.html.handlebars
+++ b/0.30.1/docs/index.html.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>

--- a/docs/index.html.handlebars
+++ b/docs/index.html.handlebars
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ramda Documentationa</title>
+    <title>Ramda Documentation</title>
     <link rel="stylesheet" type="text/css" href="../style.css">
     <script type="text/javascript" src="/js/javascript.js"></script>
 </head>


### PR DESCRIPTION
The titles of the API Docs were  `Ramda Documentationa` instead of  `Ramda Documentation` 

fixes #287 